### PR TITLE
Add mode indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ or using `VSIXInstaller.exe`.
 - Use Visual Studio's `IMultiSelectionBroker` API to track selections and
   perform transformations.
 - Keep the code base small and easy to extend.
+- Visual Studio's status bar now shows the active editing mode using three
+  letter abbreviations like `NOR` and `INS`.
 
 ## Repository Layout
 

--- a/VxHelix3/ModeManager.cs
+++ b/VxHelix3/ModeManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.VisualStudio.Shell;
 
 public sealed class ModeManager
 {
@@ -19,6 +20,15 @@ public sealed class ModeManager
 	public enum EditorMode { Normal, Insert }
 	public EditorMode Current { get; private set; } = EditorMode.Normal;
 
-	public void EnterInsert() => Current = EditorMode.Insert;
-	public void EnterNormal() => Current = EditorMode.Normal;
+        public void EnterInsert()
+        {
+                Current = EditorMode.Insert;
+                StatusBarHelper.ShowMode(Current);
+        }
+
+        public void EnterNormal()
+        {
+                Current = EditorMode.Normal;
+                StatusBarHelper.ShowMode(Current);
+        }
 }

--- a/VxHelix3/StatusBarHelper.cs
+++ b/VxHelix3/StatusBarHelper.cs
@@ -1,0 +1,21 @@
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace VxHelix3
+{
+    internal static class StatusBarHelper
+    {
+        public static void ShowMode(ModeManager.EditorMode mode)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var status = ServiceProvider.GlobalProvider.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
+            var text = mode switch
+            {
+                ModeManager.EditorMode.Normal => "NOR",
+                ModeManager.EditorMode.Insert => "INS",
+                _ => mode.ToString().ToUpperInvariant(),
+            };
+            status?.SetText($"-- {text} --");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show current mode in Visual Studio status bar
- show modes as three-letter codes (NOR, INS)
- document the status bar indicator

## Testing
- `msbuild VsHelix.sln /restore` *(fails: command not found)*
- `dotnet msbuild VsHelix.sln /restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702ee192bc832489609510d054931c