### PR TITLE
Add line selection and caret duplication commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,7 @@ or using `VSIXInstaller.exe`.
 
 The extension includes a `HelixCommandHandler` implementing basic motions like
 `w` for word forward as well as `h`, `j`, `k`, and `l` for left, down, up, and
-right movement across all selections.
+right movement across all selections.  The `x` key selects the current line or
+extends the selection to the next line when pressed repeatedly.  Pressing `C`
+copies the current selection to the line below while <kbd>Alt</kbd>+`C`
+duplicates the selection on the line above.

--- a/VxHelix3/NormalMode.cs
+++ b/VxHelix3/NormalMode.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
+using System.Windows.Input;
 using VxHelix3;
 
 namespace VxHelix3
@@ -88,27 +89,55 @@ namespace VxHelix3
 					});
 					return true;
 
-				case 'B':
-					broker.PerformActionOnAllSelections(selection =>
-					{
-						selection.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-						selection.PerformAction(PredefinedSelectionTransformations.SelectToPreviousWord);
-					});
-					return true;
+                                case 'B':
+                                        broker.PerformActionOnAllSelections(selection =>
+                                        {
+                                                selection.PerformAction(PredefinedSelectionTransformations.ClearSelection);
+                                                selection.PerformAction(PredefinedSelectionTransformations.SelectToPreviousWord);
+                                        });
+                                        return true;
 
-				case 'd':
-					DeleteSelection(view, broker);
-					// After the edit is applied, the selections are automatically collapsed
-					// at the start of the deleted region by the editor. No further action is needed.
-					return true;
+                                case 'x':
+                                        broker.PerformActionOnAllSelections(selection =>
+                                        {
+                                                if (selection.Selection.IsEmpty)
+                                                {
+                                                        selection.PerformAction(PredefinedSelectionTransformations.SelectCurrentLine);
+                                                }
+                                                else
+                                                {
+                                                        selection.PerformAction(PredefinedSelectionTransformations.SelectToNextLine);
+                                                }
+                                        });
+                                        return true;
 
-				case 'c':
-					DeleteSelection(view, broker);
-					// After the edit is applied, the selections are automatically collapsed
-					// at the start of the deleted region by the editor.
-					ModeManager.Instance.EnterInsert();
-					return true;
-			}
+                                case 'd':
+                                        DeleteSelection(view, broker);
+                                        // After the edit is applied, the selections are automatically collapsed
+                                        // at the start of the deleted region by the editor. No further action is needed.
+                                        return true;
+
+                                case 'c':
+                                        DeleteSelection(view, broker);
+                                        // After the edit is applied, the selections are automatically collapsed
+                                        // at the start of the deleted region by the editor.
+                                        ModeManager.Instance.EnterInsert();
+                                        return true;
+
+                                case 'C':
+                                        broker.PerformActionOnAllSelections(selection =>
+                                        {
+                                                if ((Keyboard.Modifiers & ModifierKeys.Alt) != 0)
+                                                {
+                                                        selection.PerformAction(PredefinedSelectionTransformations.AddCaretAbove);
+                                                }
+                                                else
+                                                {
+                                                        selection.PerformAction(PredefinedSelectionTransformations.AddCaretBelow);
+                                                }
+                                        });
+                                        return true;
+                        }
 
 			return true;
 		}


### PR DESCRIPTION
## Summary
- enhance Normal mode with new commands
  - `x` selects the current line or extends to the next line
  - `C` duplicates the selection below, `Alt+C` duplicates above
- document new commands in README

## Testing
- `msbuild VxHelix3.sln /restore` *(fails: command not found)*
- `dotnet build VxHelix3.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687090e9da8483248ffb66f2dc899206