### PR TITLE
Add SearchMode for search commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ command handler and will grow into a small set of core commands.
    `Ctrl+Alt+Click` to place additional carets.
 5. Press `w` to extend each caret to the start of the next word.
 6. Use `h`, `j`, `k`, and `l` to move all carets left, down, up, or right by one character or line.
+7. Press `/` to search using a regular expression starting at the primary caret.  The match is selected across all carets using Visual Studio's incremental search.
+8. Press `n` to repeat the last search and select the next match.
 
 The provided `VsHelixPackage` is a standard AsyncPackage.  Command handlers are
 added via MEF exports.  When the project is built in *Release* configuration it

--- a/VxHelix3/IInputMode.cs
+++ b/VxHelix3/IInputMode.cs
@@ -11,6 +11,6 @@ namespace VxHelix3
 	/// </summary>
 	internal interface IInputMode
 	{
-		bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations);
+               bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations);
 	}
 }

--- a/VxHelix3/InsertMode.cs
+++ b/VxHelix3/InsertMode.cs
@@ -11,9 +11,9 @@ namespace VxHelix3
 	/// </summary>
 	internal sealed class InsertMode : IInputMode
 	{
-		public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
-		{
-			return false;
-		}
+               public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+               {
+                       return false;
+               }
 	}
 }

--- a/VxHelix3/NormalMode.cs
+++ b/VxHelix3/NormalMode.cs
@@ -13,10 +13,17 @@ namespace VxHelix3
 	/// <summary>
 	/// Handles key input when in Normal mode.
 	/// </summary>
-	internal sealed class NormalMode : IInputMode
-	{
-		public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
-		{
+internal sealed class NormalMode : IInputMode
+        {
+                private readonly SearchMode _searchMode;
+
+                internal NormalMode(SearchMode searchMode)
+                {
+                        _searchMode = searchMode;
+                }
+
+                public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+                {
 			switch (args.TypedChar)
 			{
 				case 'i':
@@ -89,13 +96,19 @@ namespace VxHelix3
 					});
 					return true;
 
-				case 'B':
-					broker.PerformActionOnAllSelections(selection =>
-					{
-						selection.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-						selection.PerformAction(PredefinedSelectionTransformations.SelectToPreviousWord);
-					});
-					return true;
+                                case 'B':
+                                        broker.PerformActionOnAllSelections(selection =>
+                                        {
+                                                selection.PerformAction(PredefinedSelectionTransformations.ClearSelection);
+                                                selection.PerformAction(PredefinedSelectionTransformations.SelectToPreviousWord);
+                                        });
+                                        return true;
+
+                                case '/':
+                                        return _searchMode.Handle(args, view, broker, operations);
+
+                                case 'n':
+                                        return _searchMode.Handle(args, view, broker, operations);
 
 				case 'x':
 					broker.PerformActionOnAllSelections(selection =>

--- a/VxHelix3/SearchMode.cs
+++ b/VxHelix3/SearchMode.cs
@@ -1,0 +1,94 @@
+using Microsoft.VisualBasic;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Text.IncrementalSearch;
+using System.Linq;
+
+namespace VxHelix3
+{
+    /// <summary>
+    /// Handles search commands such as '/' and 'n'.
+    /// </summary>
+    internal sealed class SearchMode : IInputMode
+    {
+        private readonly ITextSearchService _searchService;
+        private readonly IIncrementalSearchFactoryService _incSearchFactory;
+        private string? _lastSearch;
+
+        internal SearchMode(ITextSearchService searchService, IIncrementalSearchFactoryService incSearchFactory)
+        {
+            _searchService = searchService;
+            _incSearchFactory = incSearchFactory;
+        }
+
+        public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+        {
+            switch (args.TypedChar)
+            {
+                case '/':
+                    DoSearch(view, broker);
+                    return true;
+                case 'n':
+                    RepeatSearch(view, broker);
+                    return true;
+            }
+
+            return false;
+        }
+
+        private void DoSearch(ITextView view, IMultiSelectionBroker broker)
+        {
+            var start = broker.PrimarySelection.ActivePoint.Position.Position;
+            var term = Interaction.InputBox("Enter search regex:", "Search", _lastSearch ?? string.Empty);
+            if (string.IsNullOrEmpty(term))
+            {
+                return;
+            }
+
+            var inc = _incSearchFactory.GetIncrementalSearch(view);
+            inc.Clear();
+            inc.SearchString = term;
+            inc.Start();
+            inc.Dismiss();
+
+            var data = new FindData(term, view.TextSnapshot)
+            {
+                FindOptions = FindOptions.UseRegularExpressions | FindOptions.Wrap | FindOptions.DoNotUpdateUI
+            };
+            var span = _searchService.FindNext(start, true, data);
+            if (span.HasValue)
+            {
+                _lastSearch = term;
+                broker.ClearSecondarySelections();
+                broker.TextView.Selection.Select(span.Value, false);
+            }
+        }
+
+        private void RepeatSearch(ITextView view, IMultiSelectionBroker broker)
+        {
+            if (string.IsNullOrEmpty(_lastSearch))
+            {
+                return;
+            }
+
+            var inc = _incSearchFactory.GetIncrementalSearch(view);
+            inc.SearchString = _lastSearch;
+            inc.SelectNextResult();
+            inc.Dismiss();
+
+            var start = broker.PrimarySelection.ActivePoint.Position.Position;
+            var data = new FindData(_lastSearch, view.TextSnapshot)
+            {
+                FindOptions = FindOptions.UseRegularExpressions | FindOptions.Wrap | FindOptions.DoNotUpdateUI
+            };
+            var next = _searchService.FindNext(start, true, data);
+            if (next.HasValue)
+            {
+                broker.ClearSecondarySelections();
+                broker.TextView.Selection.Select(next.Value, false);
+            }
+        }
+    }
+}

--- a/VxHelix3/TypeCharFilter.cs
+++ b/VxHelix3/TypeCharFilter.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Text.IncrementalSearch;
 using Microsoft.VisualStudio.Utilities;
 
 namespace VxHelix3
@@ -23,15 +24,21 @@ namespace VxHelix3
 	{
 		private const string ModeKey = nameof(TypeCharFilter) + "_mode";
 
-		private readonly IEditorOperationsFactoryService _editorOperationsFactory;
-		private readonly IInputMode _insertMode = new InsertMode();
-		private readonly IInputMode _normalMode = new NormalMode();
+                private readonly IEditorOperationsFactoryService _editorOperationsFactory;
+                private readonly IInputMode _insertMode = new InsertMode();
+                private readonly SearchMode _searchMode;
+                private readonly IInputMode _normalMode;
 
-		[ImportingConstructor]
-		internal TypeCharFilter(IEditorOperationsFactoryService editorOperationsFactory)
-		{
-			_editorOperationsFactory = editorOperationsFactory;
-		}
+                [ImportingConstructor]
+                internal TypeCharFilter(
+                        IEditorOperationsFactoryService editorOperationsFactory,
+                        ITextSearchService textSearchService,
+                        IIncrementalSearchFactoryService incrementalSearchFactory)
+                {
+                        _editorOperationsFactory = editorOperationsFactory;
+                        _searchMode = new SearchMode(textSearchService, incrementalSearchFactory);
+                        _normalMode = new NormalMode(_searchMode);
+                }
 
 		public string DisplayName => "Helix Emulation (demo)";
 
@@ -44,14 +51,14 @@ namespace VxHelix3
 			var broker = view.GetMultiSelectionBroker();
 			var ops = _editorOperationsFactory.GetEditorOperations(view);
 			
-			if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
-			{
-				return _normalMode.Handle(args, view, broker, ops);
-			}
-			else if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
-			{
-				return _insertMode.Handle(args, view, broker, ops);
-			}
+                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
+                        {
+                                return _normalMode.Handle(args, view, broker, ops);
+                        }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
+                        {
+                                return _insertMode.Handle(args, view, broker, ops);
+                        }
 
 			return false;
 		}


### PR DESCRIPTION
## Summary
- integrate Visual Studio incremental search with existing search commands
- TypeCharFilter imports `IIncrementalSearchFactoryService`
- SearchMode uses `IIncrementalSearchFactoryService` and `ITextSearchService`
- README notes incremental search usage

## Testing
- ❌ `msbuild VsHelix.sln /restore` (failed to run: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68712f1781808324a507559270d60668