### PR TITLE
Implement line open commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,6 @@ The extension includes a `HelixCommandHandler` implementing basic motions like
 right movement across all selections.  The `x` key selects the current line or
 extends the selection to the next line when pressed repeatedly.  Pressing `C`
 copies the current selection to the line below while <kbd>Alt</kbd>+`C`
-duplicates the selection on the line above.
+duplicates the selection on the line above.  Use `o` to open a new line below
+each caret and `O` to open one above.  Both commands switch to insert mode at
+the newly inserted line.


### PR DESCRIPTION
## Summary
- support `o` to open a line below the caret
- support `O` to open a line above the caret
- document the new commands

## Testing
- `xbuild VxHelix3.sln` *(fails: MSBuild not available)*

------
https://chatgpt.com/codex/tasks/task_e_6871eaccbca083248783b00ed69b2b9e