### PR TITLE
Document tab usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ and only targets Visual Studio 2022.
 ## Coding Conventions
 
 - Language: **C#** targeting .NET Framework 4.7.2.
+- Use **tabs** for indentation to match the existing source files.
 - Use Visual Studio's `IMultiSelectionBroker` API for all caret and selection
   manipulation.  Do not attempt to track caret state manually.
 - Command handlers are exported with `ICommandHandler<TypeCharCommandArgs>` and


### PR DESCRIPTION
## Summary
- clarify that tabs are used for indentation

## Testing
- `dotnet msbuild VxHelix3.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68725dde30c883248a9d2a1054f6dac6