### PR TITLE
Add comma command to clear secondary selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ each caret and `O` to open one above.  Both commands switch to insert mode at
 the newly inserted line with the indentation of the surrounding text.
 Pressing <kbd>Esc</kbd> now closes any active IntelliSense sessions before
 returning to normal mode.
+Pressing <kbd>,</kbd> clears all secondary selections, leaving a single cursor.

--- a/VxHelix3/NormalMode.cs
+++ b/VxHelix3/NormalMode.cs
@@ -142,7 +142,11 @@ namespace VxHelix3
 				case 'C':
 					AddCaretBelowLastSelection(view, broker);
 					return true;
-			}
+
+				case ',':
+					broker.ClearSecondarySelections();
+					return true;
+                        }
 
 			return true;
 		}


### PR DESCRIPTION
## Summary
- allow pressing ',' in normal mode to clear secondary selections
- document the new command

## Testing
- `dotnet msbuild VxHelix3.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_687332c3d24083248fb01643fe701d59