### PR TITLE
Improve test isolation with injectable managers

### DIFF
--- a/VsHelix.Tests/GlobalUsings.cs
+++ b/VsHelix.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/VsHelix.Tests/NormalModeTests.cs
+++ b/VsHelix.Tests/NormalModeTests.cs
@@ -1,0 +1,74 @@
+using Moq;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Text.Operations;
+using VsHelix;
+
+namespace VsHelix.Tests;
+
+public class NormalModeTests
+{
+	[Fact]
+	public void Typing_i_enters_insert_mode()
+	{
+	   var manager = new ModeManager();
+	   var selections = new SelectionManager();
+	   manager.EnterNormal();
+	   manager.ShowModeAction = _ => { };
+
+	    var snapshot = new Mock<ITextSnapshot>().Object;
+	    var buffer = new Mock<ITextBuffer>().Object;
+	    var view = new Mock<ITextView>();
+	    view.SetupGet(v => v.TextSnapshot).Returns(snapshot);
+	    view.SetupGet(v => v.TextBuffer).Returns(buffer);
+
+	    var broker = new Mock<IMultiSelectionBroker>();
+	    broker.SetupGet(b => b.TextView).Returns(view.Object);
+	    broker.SetupGet(b => b.AllSelections).Returns(Array.Empty<ISelection>());
+	    broker.Setup(b => b.PerformActionOnAllSelections(It.IsAny<Action<ISelectionTransformer>>()))
+		 .Callback(() => { });
+
+	    var ops = new Mock<IEditorOperations>().Object;
+	    var args = new TypeCharCommandArgs(view.Object, buffer, 'i');
+
+	    var mode = new NormalMode(manager, selections);
+	    var handled = mode.Handle(args, view.Object, broker.Object, ops);
+
+	    Assert.True(handled);
+	    Assert.Equal(ModeManager.EditorMode.Insert, manager.Current);
+	}
+
+	[Fact]
+	public void Typing_w_invokes_selection_action()
+	{
+	   var manager = new ModeManager();
+	   var selections = new SelectionManager();
+	   manager.EnterNormal();
+	   manager.ShowModeAction = _ => { };
+
+	    var snapshot = new Mock<ITextSnapshot>().Object;
+	    var buffer = new Mock<ITextBuffer>().Object;
+	    var view = new Mock<ITextView>();
+	    view.SetupGet(v => v.TextSnapshot).Returns(snapshot);
+	    view.SetupGet(v => v.TextBuffer).Returns(buffer);
+
+	    var broker = new Mock<IMultiSelectionBroker>();
+	    broker.SetupGet(b => b.TextView).Returns(view.Object);
+	    broker.SetupGet(b => b.AllSelections).Returns(Array.Empty<ISelection>());
+
+	    var called = false;
+	    broker.Setup(b => b.PerformActionOnAllSelections(It.IsAny<Action<ISelectionTransformer>>()))
+		 .Callback(() => called = true);
+
+	    var ops = new Mock<IEditorOperations>().Object;
+	    var args = new TypeCharCommandArgs(view.Object, buffer, 'w');
+
+	    var mode = new NormalMode(manager, selections);
+	    var handled = mode.Handle(args, view.Object, broker.Object, ops);
+
+	    Assert.True(handled);
+	    Assert.True(called);
+	    Assert.Equal(ModeManager.EditorMode.Normal, manager.Current);
+	}
+}

--- a/VsHelix.Tests/VsHelix.Tests.csproj
+++ b/VsHelix.Tests/VsHelix.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VsHelix\VsHelix.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/VsHelix.sln
+++ b/VsHelix.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36221.1 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VsHelix", "VsHelix\VsHelix.csproj", "{59666F82-FAAD-470D-B296-003075A2A812}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VsHelix.Tests", "VsHelix.Tests\VsHelix.Tests.csproj", "{D60C4BD1-FC7A-4A25-9F8B-55DEF8DC780F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{59666F82-FAAD-470D-B296-003075A2A812}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59666F82-FAAD-470D-B296-003075A2A812}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59666F82-FAAD-470D-B296-003075A2A812}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D60C4BD1-FC7A-4A25-9F8B-55DEF8DC780F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D60C4BD1-FC7A-4A25-9F8B-55DEF8DC780F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D60C4BD1-FC7A-4A25-9F8B-55DEF8DC780F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D60C4BD1-FC7A-4A25-9F8B-55DEF8DC780F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -3,35 +3,37 @@ using Microsoft.VisualStudio.Shell;
 
 namespace VsHelix
 {
-    public sealed class ModeManager
-    {
-        // 1. Private constructor to prevent instantiation from outside
-        private ModeManager()
-        {
-            // Initialization code can go here
-        }
+	public sealed class ModeManager
+	{
+		// 1. Private constructor to prevent instantiation from outside
+		internal ModeManager()
+		{
+			// Initialization code can go here
+		}
 
-        // 2. A private, static, and readonly field to hold the lazy-initialized instance.
-        private static readonly Lazy<ModeManager> lazyInstance =
-            new Lazy<ModeManager>(() => new ModeManager());
+		// 2. A private, static, and readonly field to hold the lazy-initialized instance.
+		private static readonly Lazy<ModeManager> lazyInstance =
+			new Lazy<ModeManager>(() => new ModeManager());
 
-        // 3. A public static property to provide the single global access point.
-        public static ModeManager Instance => lazyInstance.Value;
+		// 3. A public static property to provide the single global access point.
+		public static ModeManager Instance => lazyInstance.Value;
 
-        // --- Your existing class members ---
-        public enum EditorMode { Normal, Insert }
-        public EditorMode Current { get; private set; } = EditorMode.Normal;
+		// --- Your existing class members ---
+		public enum EditorMode { Normal, Insert }
+		public EditorMode Current { get; private set; } = EditorMode.Normal;
 
-        public void EnterInsert()
-        {
-            Current = EditorMode.Insert;
-            StatusBarHelper.ShowMode(Current);
-        }
+		internal Action<EditorMode> ShowModeAction { get; set; } = StatusBarHelper.ShowMode;
 
-        public void EnterNormal()
-        {
-            Current = EditorMode.Normal;
-            StatusBarHelper.ShowMode(Current);
-        }
-    }
+		public void EnterInsert()
+		{
+			Current = EditorMode.Insert;
+			ShowModeAction(Current);
+		}
+
+		public void EnterNormal()
+		{
+			Current = EditorMode.Normal;
+			ShowModeAction(Current);
+		}
+	}
 }

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -18,38 +18,47 @@ namespace VsHelix
 	/// <summary>
 	/// Handles key input when in Normal mode.
 	/// </summary>
-	internal sealed class NormalMode : IInputMode
-	{
-		public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
-		{
+       internal sealed class NormalMode : IInputMode
+       {
+               private readonly ModeManager modeManager;
+               private readonly SelectionManager selectionManager;
+
+               public NormalMode(ModeManager modeManager = null, SelectionManager selectionManager = null)
+               {
+                       this.modeManager = modeManager ?? ModeManager.Instance;
+                       this.selectionManager = selectionManager ?? SelectionManager.Instance;
+               }
+
+               public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+               {
 			switch (args.TypedChar)
 			{
 				case 'i':
 					// Save the current selections before entering insert mode.
-					SelectionManager.Instance.SaveSelections(broker);
+                                        selectionManager.SaveSelections(broker);
 
 					// For the 'insert' command, we move the caret to the start of each selection.
 					broker.PerformActionOnAllSelections(selection => MoveCaretToSelectionStart(selection));
-					ModeManager.Instance.EnterInsert();
+                                        modeManager.EnterInsert();
 					return true;
 
 				case 'a':
 					// Save the current selections before entering insert mode.
-					SelectionManager.Instance.SaveSelections(broker);
+                                        selectionManager.SaveSelections(broker);
 
 					// For the 'append' command, move the caret to the end of the selection.
 					broker.PerformActionOnAllSelections(selection => MoveCaretToSelectionEnd(selection));
-					ModeManager.Instance.EnterInsert();
+                                        modeManager.EnterInsert();
 					return true;
 
 				case 'o':
 					AddLine(view, broker, operations, above: false);
-					ModeManager.Instance.EnterInsert();
+                                        modeManager.EnterInsert();
 					return true;
 
 				case 'O':
 					AddLine(view, broker, operations, above: true);
-					ModeManager.Instance.EnterInsert();
+                                        modeManager.EnterInsert();
 					return true;
 
 				case 'w':
@@ -136,7 +145,7 @@ namespace VsHelix
 					DeleteSelection(view, broker);
 					// After the edit is applied, the selections are automatically collapsed
 					// at the start of the deleted region by the editor.
-					ModeManager.Instance.EnterInsert();
+                                        modeManager.EnterInsert();
 					return true;
 
 				case 'C':

--- a/VsHelix/SelectionManager.cs
+++ b/VsHelix/SelectionManager.cs
@@ -34,8 +34,8 @@ namespace VsHelix
 
 		private List<TrackedSelection> selectionsToRestore;
 
-		// Private constructor to enforce singleton pattern.
-		private SelectionManager() { }
+				// Private constructor to enforce singleton pattern.
+				internal SelectionManager() { }
 
 		/// <summary>
 		/// Gets a value indicating whether there are selections saved and waiting to be restored.

--- a/VsHelix/VsHelix.csproj
+++ b/VsHelix/VsHelix.csproj
@@ -18,4 +18,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Build" Version="17.9.2092" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.6.36389" ExcludeAssets="runtime" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>VsHelix.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- make `ModeManager` and `SelectionManager` constructible for test injection
- inject fresh managers into `NormalModeTests`
- expose internals to the test project for access

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet test VsHelix.Tests/VsHelix.Tests.csproj -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b8326b8883249e7779fe1b11c7fe