### PR TITLE
Add undo/redo and optional yank on delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ the newly inserted line with the indentation of the surrounding text.
 Press `p` pastes clipboard text after each selection. When the clipboard content
 ends with a newline it is inserted on its own line; otherwise it is inserted at
 the caret positions. Use `y` to yank the current selections to the clipboard.
-The `d` and `c` commands now yank before deleting so that pasted text is
-available afterwards.
+The `d` and `c` commands yank before deleting so that pasted text is available
+afterwards. Hold <kbd>Alt</kbd> while pressing `d` or `c` to delete without
+copying.
+Press `u` to undo and `U` to redo the last action.
 Pressing <kbd>Esc</kbd> now closes any active IntelliSense sessions before
 returning to normal mode.
 Pressing <kbd>,</kbd> clears all secondary selections, leaving a single cursor.

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -173,20 +173,36 @@ namespace VsHelix
 					YankSelections(view, broker);
 					return true;
 
-				case 'd':
-					YankSelections(view, broker);
-					DeleteSelection(view, broker);
-					// After the edit is applied, the selections are automatically collapsed
-					// at the start of the deleted region by the editor. No further action is needed.
-					return true;
+                                case 'd':
+                                        var altDown = (Keyboard.Modifiers & ModifierKeys.Alt) != 0;
+                                        if (!altDown)
+                                        {
+                                                YankSelections(view, broker);
+                                        }
+                                        DeleteSelection(view, broker);
+                                        // After the edit is applied, the selections are automatically collapsed
+                                        // at the start of the deleted region by the editor. No further action is needed.
+                                        return true;
 
-				case 'c':
-					YankSelections(view, broker);
-					DeleteSelection(view, broker);
-					// After the edit is applied, the selections are automatically collapsed
-					// at the start of the deleted region by the editor.
-					ModeManager.Instance.EnterInsert();
-					return true;
+                                case 'c':
+                                        altDown = (Keyboard.Modifiers & ModifierKeys.Alt) != 0;
+                                        if (!altDown)
+                                        {
+                                                YankSelections(view, broker);
+                                        }
+                                        DeleteSelection(view, broker);
+                                        // After the edit is applied, the selections are automatically collapsed
+                                        // at the start of the deleted region by the editor.
+                                        ModeManager.Instance.EnterInsert();
+                                        return true;
+
+                                case 'u':
+                                        operations.Undo();
+                                        return true;
+
+                                case 'U':
+                                        operations.Redo();
+                                        return true;
 
 				case 'p':
 					Paste(view, broker);


### PR DESCRIPTION
## Summary
- handle `u` and `U` in normal mode to undo/redo
- copy deleted text on `d` and `c` unless Alt is held
- document new behaviour in README

## Testing
- `xbuild VsHelix.sln` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_687530fb53948324bbe4e442a6c3799b