### PR TITLE
Ensure normal mode selects one character

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ command handler and will grow into a small set of core commands.
    `Ctrl+Alt+Click` to place additional carets.
 5. Press `w` to extend each caret to the start of the next word.
 6. Use `h`, `j`, `k`, and `l` to move all carets left, down, up, or right by one character or line.
+7. When in normal mode the caret highlights the character under it. Moving with
+   `h`, `j`, `k`, `l`, the arrow keys or by clicking the mouse keeps this
+   single-character selection.
 
 The provided `VsHelixPackage` is a standard AsyncPackage.  Command handlers are
 added via MEF exports.  When the project is built in *Release* configuration it

--- a/VsHelix/NormalModeSelectionBehavior.cs
+++ b/VsHelix/NormalModeSelectionBehavior.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Extensibility;
+using Microsoft.VisualStudio.Extensibility.Editor;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace VsHelix
+{
+	[Export(typeof(IWpfTextViewCreationListener))]
+	[ContentType("text")]
+	[TextViewRole(PredefinedTextViewRoles.Editable)]
+	[VisualStudioContribution]
+	internal sealed class NormalModeSelectionBehavior : IWpfTextViewCreationListener
+	{
+	    public void TextViewCreated(IWpfTextView textView)
+	    {
+	        var broker = textView.GetMultiSelectionBroker();
+	        textView.Caret.PositionChanged += (s, e) => EnsureSelection(textView, broker);
+	        textView.Selection.SelectionChanged += (s, e) => EnsureSelection(textView, broker);
+	    }
+
+	    private void EnsureSelection(ITextView view, IMultiSelectionBroker broker)
+	    {
+	        if (ModeManager.Instance.Current != ModeManager.EditorMode.Normal)
+	        {
+	            return;
+	        }
+
+	        broker.PerformActionOnAllSelections(sel =>
+	        {
+	            if (sel.Selection.IsEmpty)
+	            {
+	                var point = sel.Selection.ActivePoint.Position;
+	                var snapshot = point.Snapshot;
+	                if (point.Position < snapshot.Length)
+	                {
+	                    var start = new SnapshotPoint(snapshot, point.Position);
+	                    var end = new SnapshotPoint(snapshot, point.Position + 1);
+	                    var span = new VirtualSnapshotSpan(new SnapshotSpan(start, end));
+	                    sel.MoveTo(span.Start, false, PositionAffinity.Successor);
+	                    sel.MoveTo(span.End, true, PositionAffinity.Successor);
+	                }
+	            }
+	        });
+	    }
+	}
+}


### PR DESCRIPTION
## Summary
- keep a single-character selection whenever the caret moves in normal mode
- document the behaviour in the readme

## Testing
- `dotnet build VsHelix.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68753464d88c8324bf261d2a4c940e88