### PR TITLE
Handle zero-length selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ command handler and will grow into a small set of core commands.
 7. When in normal mode the caret highlights the character under it. Moving with
    `h`, `j`, `k`, `l`, the arrow keys or by clicking the mouse keeps this
    single-character selection.
+8. Commands like `d` or `a` also treat a lone caret as selecting the character
+   under it, so operations always act on at least one character. The highlight
+   is drawn by the extension without expanding the actual selection, avoiding
+   Visual Studio's multi-occurrence highlight.
 
 The provided `VsHelixPackage` is a standard AsyncPackage.  Command handlers are
 added via MEF exports.  When the project is built in *Release* configuration it

--- a/VsHelix/CaretHighlightTagger.cs
+++ b/VsHelix/CaretHighlightTagger.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Utilities;
+
+namespace VsHelix
+{
+	internal static class CaretHighlightFormat
+	{
+		public const string Name = "VsHelixCaretHighlight";
+	}
+
+	[Export(typeof(EditorFormatDefinition))]
+	[Name(CaretHighlightFormat.Name)]
+	[UserVisible(true)]
+	internal sealed class CaretHighlightDefinition : MarkerFormatDefinition
+	{
+		public CaretHighlightDefinition()
+		{
+			BackgroundColor = System.Windows.Media.Colors.LightGray;
+			DisplayName = "VsHelix caret highlight";
+			ZOrder = 5;
+		}
+	}
+
+	[Export(typeof(IViewTaggerProvider))]
+	[ContentType("text")]
+	[TagType(typeof(TextMarkerTag))]
+	internal sealed class CaretHighlightProvider : IViewTaggerProvider
+	{
+		public ITagger<T> CreateTagger<T>(ITextView textView, ITextBuffer buffer) where T : ITag
+		{
+			if (textView.TextBuffer != buffer)
+			return null;
+			return textView.Properties.GetOrCreateSingletonProperty(() => new CaretHighlightTagger(textView)) as ITagger<T>;
+		}
+	}
+
+	internal sealed class CaretHighlightTagger : ITagger<TextMarkerTag>
+	{
+		private readonly ITextView _view;
+		private readonly IMultiSelectionBroker _broker;
+
+		public CaretHighlightTagger(ITextView view)
+		{
+			view ??= throw new ArgumentNullException(nameof(view));
+			 _view = view;
+			 _broker = view.GetMultiSelectionBroker();
+			 _view.Caret.PositionChanged += OnChanged;
+			 _view.Selection.SelectionChanged += OnChanged;
+			 _view.LayoutChanged += (s, e) => RaiseTagsChanged();
+		}
+
+		public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
+
+		private void OnChanged(object sender, EventArgs e) => RaiseTagsChanged();
+
+		private void RaiseTagsChanged()
+		{
+			var snapshot = _view.TextSnapshot;
+			TagsChanged?.Invoke(this, new SnapshotSpanEventArgs(new SnapshotSpan(snapshot, 0, snapshot.Length)));
+		}
+
+		public IEnumerable<ITagSpan<TextMarkerTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+		{
+			if (spans.Count == 0 || ModeManager.Instance.Current != ModeManager.EditorMode.Normal)
+			yield break;
+
+			var snapshot = _view.TextSnapshot;
+			foreach (var sel in _broker.AllSelections)
+			{
+				var span = SelectionUtilities.GetEffectiveSpan(sel, snapshot);
+				if (span.Length == 0)
+				continue;
+
+				foreach (var visible in spans)
+				{
+			var inter = visible.Intersection(span);
+			if (inter != null)
+			{
+					yield return new TagSpan<TextMarkerTag>(inter.Value, new TextMarkerTag(CaretHighlightFormat.Name));
+					break;
+			}
+				}
+			}
+		}
+	}
+}

--- a/VsHelix/EscapeKeyHandler.cs
+++ b/VsHelix/EscapeKeyHandler.cs
@@ -45,8 +45,8 @@ namespace VsHelix
 				}
 
 				// Now that the selection is handled, switch the mode.
-				ModeManager.Instance.EnterNormal();
-				return true; // Command was handled.
+                               ModeManager.Instance.EnterNormal();
+                               return true; // Command was handled.
 			}
 
 			// In normal mode, also cancel 'esc' keys as that would clear multiple selections.

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -169,13 +169,13 @@ namespace VsHelix
 		/// <summary>
 		/// Handles a typed character command in Normal mode by dispatching to the appropriate action.
 		/// </summary>
-		public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
-		{
-			if (_commandMap.TryGetValue(args.TypedChar, out var handler))
-			{
-				// Found a command for this key – execute it.
-				return handler(args, view, broker, operations);
-			}
+                public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+                {
+                        if (_commandMap.TryGetValue(args.TypedChar, out var handler))
+                        {
+                                // Found a command for this key – execute it.
+                                return handler(args, view, broker, operations);
+                        }
 
 			// Unrecognized key in Normal mode: do nothing (but consume the input to prevent insertion).
 			return true;
@@ -462,12 +462,9 @@ namespace VsHelix
 			using (var edit = view.TextBuffer.CreateEdit())
 			{
 				// Delete each selection (process in reverse order for safety in overlapping scenarios).
-				foreach (var sel in selections.OrderByDescending(s => s.Start.Position))
-				{
-					if (sel.IsEmpty) continue;
-
-					// Determine span to delete.
-					var spanToDelete = new SnapshotSpan(sel.Start.Position, sel.End.Position);
+                               foreach (var sel in selections.OrderByDescending(s => s.Start.Position))
+                               {
+                                       var spanToDelete = SelectionUtilities.GetEffectiveSpan(sel, view.TextSnapshot);
 					// If selection covers whole line content (linewise), include the line break in deletion.
 					if (IsLinewiseSelection(sel, view.TextSnapshot))
 					{
@@ -520,8 +517,8 @@ namespace VsHelix
 			foreach (var sel in selections)
 			{
 				// Get the text covered by the selection.
-				var span = new SnapshotSpan(sel.Start.Position, sel.End.Position);
-				string text = span.GetText();
+                               var span = SelectionUtilities.GetEffectiveSpan(sel, snapshot);
+                               string text = span.GetText();
 				bool isLinewise = IsLinewiseSelection(sel, snapshot);
 
 				// If selection was linewise, append a newline (since selection excluded the line break).

--- a/VsHelix/SelectionUtilities.cs
+++ b/VsHelix/SelectionUtilities.cs
@@ -1,0 +1,27 @@
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Utilities;
+
+namespace VsHelix
+{
+	internal static class SelectionUtilities
+	{
+		/// <summary>
+		/// Returns the span covered by a selection, expanding empty selections to one character when possible.
+		/// </summary>
+		public static SnapshotSpan GetEffectiveSpan(Selection sel, ITextSnapshot snapshot)
+		{
+			if (!sel.IsEmpty)
+			{
+				return new SnapshotSpan(sel.Start.Position, sel.End.Position);
+			}
+
+			int pos = sel.ActivePoint.Position.Position;
+			if (pos < snapshot.Length)
+			{
+				return new SnapshotSpan(snapshot, pos, 1);
+			}
+			return new SnapshotSpan(snapshot, pos, 0);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- ensure normal mode always shows a 1‑character highlight
- treat empty selections as 1 character for all commands
- remove selection expansion so other occurrences aren't highlighted
- document new behaviour

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68755166093c8324aff436696e70fe63