### PR TITLE
Add insert-style caret helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ command handler and will grow into a small set of core commands.
    `Ctrl+Alt+Click` to place additional carets.
 5. Press `w` to extend each caret to the start of the next word.
 6. Use `h`, `j`, `k`, and `l` to move all carets left, down, up, or right by one character or line.
-7. When in normal mode the caret highlights the character under it. Moving with
-   `h`, `j`, `k`, `l`, the arrow keys or by clicking the mouse keeps this
-   single-character selection.
+7. Carets display as thin vertical bars in both modes for a consistent insert-style look.
 
 The provided `VsHelixPackage` is a standard AsyncPackage.  Command handlers are
 added via MEF exports.  When the project is built in *Release* configuration it

--- a/VsHelix/CaretHelper.cs
+++ b/VsHelix/CaretHelper.cs
@@ -1,0 +1,17 @@
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace VsHelix
+{
+	internal static class CaretHelper
+	{
+		public static void DisplayInsertCarets(ITextView view, IMultiSelectionBroker broker)
+		{
+foreach (var sel in broker.AllSelections)
+{
+view.Caret.MoveTo(sel.ActivePoint.Position, PositionAffinity.Successor);
+}
+view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, false);
+		}
+	}
+}

--- a/VsHelix/EscapeKeyHandler.cs
+++ b/VsHelix/EscapeKeyHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Extensibility;
+using Microsoft.VisualStudio.Extensibility.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
@@ -45,7 +46,7 @@ namespace VsHelix
 				}
 
 				// Now that the selection is handled, switch the mode.
-				ModeManager.Instance.EnterNormal();
+ModeManager.Instance.EnterNormal(view, broker);
 				return true; // Command was handled.
 			}
 

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Extensibility.Editor;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
 
 namespace VsHelix
 {
@@ -21,17 +24,19 @@ namespace VsHelix
         // --- Your existing class members ---
         public enum EditorMode { Normal, Insert }
         public EditorMode Current { get; private set; } = EditorMode.Normal;
-
-        public void EnterInsert()
-        {
-            Current = EditorMode.Insert;
-            StatusBarHelper.ShowMode(Current);
-        }
-
-        public void EnterNormal()
-        {
-            Current = EditorMode.Normal;
-            StatusBarHelper.ShowMode(Current);
-        }
+		
+		public void EnterInsert(ITextView view, IMultiSelectionBroker broker)
+		{
+		Current = EditorMode.Insert;
+		StatusBarHelper.ShowMode(Current);
+		CaretHelper.DisplayInsertCarets(view, broker);
+		}
+		
+		public void EnterNormal(ITextView view, IMultiSelectionBroker broker)
+		{
+		Current = EditorMode.Normal;
+		StatusBarHelper.ShowMode(Current);
+		CaretHelper.DisplayInsertCarets(view, broker);
+		}
     }
 }

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -85,31 +85,31 @@ namespace VsHelix
 			_commandMap['i'] = (args, view, broker, ops) =>
 			{
 				// Enter Insert mode at the start of each selection.
-				SelectionManager.Instance.SaveSelections(broker);
-				broker.PerformActionOnAllSelections(sel => MoveCaretToSelectionStart(sel));
-				ModeManager.Instance.EnterInsert();
+SelectionManager.Instance.SaveSelections(broker);
+broker.PerformActionOnAllSelections(sel => MoveCaretToSelectionStart(sel));
+ModeManager.Instance.EnterInsert(view, broker);
 				return true;
 			};
 			_commandMap['a'] = (args, view, broker, ops) =>
 			{
 				// Enter Insert mode at the end of each selection (append).
-				SelectionManager.Instance.SaveSelections(broker);
-				broker.PerformActionOnAllSelections(sel => MoveCaretToSelectionEnd(sel));
-				ModeManager.Instance.EnterInsert();
+SelectionManager.Instance.SaveSelections(broker);
+broker.PerformActionOnAllSelections(sel => MoveCaretToSelectionEnd(sel));
+ModeManager.Instance.EnterInsert(view, broker);
 				return true;
 			};
 			_commandMap['o'] = (args, view, broker, ops) =>
 			{
 				// Open a new line *below* each selection and enter Insert mode.
-				AddLine(view, broker, ops, above: false);
-				ModeManager.Instance.EnterInsert();
+AddLine(view, broker, ops, above: false);
+ModeManager.Instance.EnterInsert(view, broker);
 				return true;
 			};
 			_commandMap['O'] = (args, view, broker, ops) =>
 			{
 				// Open a new line *above* each selection and enter Insert mode.
-				AddLine(view, broker, ops, above: true);
-				ModeManager.Instance.EnterInsert();
+AddLine(view, broker, ops, above: true);
+ModeManager.Instance.EnterInsert(view, broker);
 				return true;
 			};
 			_commandMap['x'] = (args, view, broker, ops) =>
@@ -198,7 +198,7 @@ namespace VsHelix
 
 			if (switchToInsert)
 			{
-				ModeManager.Instance.EnterInsert();
+ModeManager.Instance.EnterInsert(view, broker);
 			}
 			return true;
 		}


### PR DESCRIPTION
## Summary
- add a `CaretHelper` utility
- make `ModeManager` update carets when changing mode
- update command handlers to use the new mode APIs
- show thin bar carets in both modes
- document caret appearance

## Testing
- `dotnet msbuild VsHelix.sln /restore`

------
https://chatgpt.com/codex/tasks/task_e_687568b3d830832494f27ab23430323a