### PR TITLE
Add Helix-style search

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ Press `u` to undo and `U` to redo the last action.
 Pressing <kbd>Esc</kbd> now closes any active IntelliSense sessions before
 returning to normal mode.
 Pressing <kbd>,</kbd> clears all secondary selections, leaving a single cursor.
+Use `s` to select all matches of a regex typed inline. `/` performs an incremental search that highlights matches as you type. Press **Enter** to accept the search or **Esc** to cancel.

--- a/VsHelix/BackspaceKeyHandler.cs
+++ b/VsHelix/BackspaceKeyHandler.cs
@@ -7,26 +7,26 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace VsHelix
 {
-[Export(typeof(ICommandHandler))]
-[ContentType("text")]
-[TextViewRole(PredefinedTextViewRoles.Editable)]
-[Name(nameof(BackspaceKeyHandler))]
-[Order(Before = "Backspace")]
-[VisualStudioContribution]
-internal sealed class BackspaceKeyHandler : ICommandHandler<BackspaceKeyCommandArgs>
-{
-public string DisplayName => "Helix Backspace Handler";
+	[Export(typeof(ICommandHandler))]
+	[ContentType("text")]
+	[TextViewRole(PredefinedTextViewRoles.Editable)]
+	[Name(nameof(BackspaceKeyHandler))]
+	[Order(Before = "Backspace")]
+	[VisualStudioContribution]
+	internal sealed class BackspaceKeyHandler : ICommandHandler<BackspaceKeyCommandArgs>
+	{
+		public string DisplayName => "Helix Backspace Handler";
 
-public CommandState GetCommandState(BackspaceKeyCommandArgs args) => CommandState.Available;
+		public CommandState GetCommandState(BackspaceKeyCommandArgs args) => CommandState.Available;
 
-public bool ExecuteCommand(BackspaceKeyCommandArgs args, CommandExecutionContext context)
-{
-if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
-{
-ModeManager.Instance.Search.HandleBackspace();
-return true;
-}
-return false;
-}
-}
+		public bool ExecuteCommand(BackspaceKeyCommandArgs args, CommandExecutionContext context)
+		{
+			if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
+			{
+				ModeManager.Instance.Search.HandleBackspace();
+				return true;
+			}
+			return false;
+		}
+	}
 }

--- a/VsHelix/BackspaceKeyHandler.cs
+++ b/VsHelix/BackspaceKeyHandler.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Extensibility;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Utilities;
+
+namespace VsHelix
+{
+[Export(typeof(ICommandHandler))]
+[ContentType("text")]
+[TextViewRole(PredefinedTextViewRoles.Editable)]
+[Name(nameof(BackspaceKeyHandler))]
+[Order(Before = "Backspace")]
+[VisualStudioContribution]
+internal sealed class BackspaceKeyHandler : ICommandHandler<BackspaceKeyCommandArgs>
+{
+public string DisplayName => "Helix Backspace Handler";
+
+public CommandState GetCommandState(BackspaceKeyCommandArgs args) => CommandState.Available;
+
+public bool ExecuteCommand(BackspaceKeyCommandArgs args, CommandExecutionContext context)
+{
+if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
+{
+ModeManager.Instance.Search.HandleBackspace();
+return true;
+}
+return false;
+}
+}
+}

--- a/VsHelix/Command1.cs
+++ b/VsHelix/Command1.cs
@@ -6,45 +6,45 @@ using Microsoft.VisualStudio.Extensibility.Shell;
 
 namespace VsHelix
 {
-    /// <summary>
-    /// Command1 handler.
-    /// </summary>
-    [VisualStudioContribution]
-    internal class Command1 : Command
-    {
-        private readonly TraceSource logger;
+	/// <summary>
+	/// Command1 handler.
+	/// </summary>
+	[VisualStudioContribution]
+	internal class Command1 : Command
+	{
+		private readonly TraceSource logger;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Command1"/> class.
-        /// </summary>
-        /// <param name="traceSource">Trace source instance to utilize.</param>
-        public Command1(TraceSource traceSource)
-        {
-            // This optional TraceSource can be used for logging in the command. You can use dependency injection to access
-            // other services here as well.
-            this.logger = Requires.NotNull(traceSource, nameof(traceSource));
-        }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Command1"/> class.
+		/// </summary>
+		/// <param name="traceSource">Trace source instance to utilize.</param>
+		public Command1(TraceSource traceSource)
+		{
+			// This optional TraceSource can be used for logging in the command. You can use dependency injection to access
+			// other services here as well.
+			this.logger = Requires.NotNull(traceSource, nameof(traceSource));
+		}
 
-        /// <inheritdoc />
-        public override CommandConfiguration CommandConfiguration => new("%VsHelix.Command1.DisplayName%")
-        {
-            // Use this object initializer to set optional parameters for the command. The required parameter,
-            // displayName, is set above. DisplayName is localized and references an entry in .vsextension\string-resources.json.
-            Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
-            Placements = [CommandPlacement.KnownPlacements.ExtensionsMenu],
-        };
+		/// <inheritdoc />
+		public override CommandConfiguration CommandConfiguration => new("%VsHelix.Command1.DisplayName%")
+		{
+			// Use this object initializer to set optional parameters for the command. The required parameter,
+			// displayName, is set above. DisplayName is localized and references an entry in .vsextension\string-resources.json.
+			Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+			Placements = [CommandPlacement.KnownPlacements.ExtensionsMenu],
+		};
 
-        /// <inheritdoc />
-        public override Task InitializeAsync(CancellationToken cancellationToken)
-        {
-            // Use InitializeAsync for any one-time setup or initialization.
-            return base.InitializeAsync(cancellationToken);
-        }
+		/// <inheritdoc />
+		public override Task InitializeAsync(CancellationToken cancellationToken)
+		{
+			// Use InitializeAsync for any one-time setup or initialization.
+			return base.InitializeAsync(cancellationToken);
+		}
 
-        /// <inheritdoc />
-        public override async Task ExecuteCommandAsync(IClientContext context, CancellationToken cancellationToken)
-        {
-            await this.Extensibility.Shell().ShowPromptAsync("Hello2 from an extension!", PromptOptions.OK, cancellationToken);
-        }
-    }
+		/// <inheritdoc />
+		public override async Task ExecuteCommandAsync(IClientContext context, CancellationToken cancellationToken)
+		{
+			await this.Extensibility.Shell().ShowPromptAsync("Hello2 from an extension!", PromptOptions.OK, cancellationToken);
+		}
+	}
 }

--- a/VsHelix/EnterKeyHandler.cs
+++ b/VsHelix/EnterKeyHandler.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.Composition;
+using System.Windows.Controls;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Extensibility;
 using Microsoft.VisualStudio.Text.Editor;
@@ -7,26 +8,30 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace VsHelix
 {
-[Export(typeof(ICommandHandler))]
-[ContentType("text")]
-[TextViewRole(PredefinedTextViewRoles.Editable)]
-[Name(nameof(EnterKeyHandler))]
-[Order(Before = "Return")]
-[VisualStudioContribution]
-internal sealed class EnterKeyHandler : ICommandHandler<ReturnKeyCommandArgs>
-{
-public string DisplayName => "Helix Enter Handler";
+	[Export(typeof(ICommandHandler))]
+	[ContentType("text")]
+	[TextViewRole(PredefinedTextViewRoles.Editable)]
+	[Name(nameof(EnterKeyHandler))]
+	[Order(Before = "Return")]
+	[VisualStudioContribution]
+	internal sealed class EnterKeyHandler : ICommandHandler<ReturnKeyCommandArgs>
+	{
+		public string DisplayName => "Helix Enter Handler";
 
-public CommandState GetCommandState(ReturnKeyCommandArgs args) => CommandState.Available;
+		public CommandState GetCommandState(ReturnKeyCommandArgs args) => CommandState.Available;
 
-public bool ExecuteCommand(ReturnKeyCommandArgs args, CommandExecutionContext context)
-{
-if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
-{
-ModeManager.Instance.Search.Finish();
-return true;
-}
-return false;
-}
-}
+		public bool ExecuteCommand(ReturnKeyCommandArgs args, CommandExecutionContext context)
+		{
+			if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
+			{
+				if (SelectionManager.Instance.HasSavedSelections)
+				{
+					SelectionManager.Instance.ClearSelections();
+				}
+				ModeManager.Instance.Search.Finish();
+				return true;
+			}
+			return false;
+		}
+	}
 }

--- a/VsHelix/EnterKeyHandler.cs
+++ b/VsHelix/EnterKeyHandler.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Extensibility;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Utilities;
+
+namespace VsHelix
+{
+[Export(typeof(ICommandHandler))]
+[ContentType("text")]
+[TextViewRole(PredefinedTextViewRoles.Editable)]
+[Name(nameof(EnterKeyHandler))]
+[Order(Before = "Return")]
+[VisualStudioContribution]
+internal sealed class EnterKeyHandler : ICommandHandler<ReturnKeyCommandArgs>
+{
+public string DisplayName => "Helix Enter Handler";
+
+public CommandState GetCommandState(ReturnKeyCommandArgs args) => CommandState.Available;
+
+public bool ExecuteCommand(ReturnKeyCommandArgs args, CommandExecutionContext context)
+{
+if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
+{
+ModeManager.Instance.Search.Finish();
+return true;
+}
+return false;
+}
+}
+}

--- a/VsHelix/EscapeKeyHandler.cs
+++ b/VsHelix/EscapeKeyHandler.cs
@@ -31,12 +31,12 @@ namespace VsHelix
 
 		public bool ExecuteCommand(EscapeKeyCommandArgs args, CommandExecutionContext context)
 		{
-			if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
-			{
-				var view = args.TextView;
-				_completionBroker.DismissAllSessions(view);
-				// Get the TextView from the command arguments (args), not the context.
-				var broker = view.GetMultiSelectionBroker();
+                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
+                        {
+                                var view = args.TextView;
+                                _completionBroker.DismissAllSessions(view);
+                                // Get the TextView from the command arguments (args), not the context.
+                                var broker = view.GetMultiSelectionBroker();
 
 				// Check if the SelectionManager has selections waiting to be restored.
 				if (SelectionManager.Instance.HasSavedSelections)
@@ -46,9 +46,20 @@ namespace VsHelix
 				}
 
 				// Now that the selection is handled, switch the mode.
-				ModeManager.Instance.EnterNormal(view, broker);
-				return true; // Command was handled.
-			}
+                                ModeManager.Instance.EnterNormal(view, broker);
+                                return true; // Command was handled.
+                        }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search)
+                        {
+                                var view = args.TextView;
+                                var broker = view.GetMultiSelectionBroker();
+                                if (SelectionManager.Instance.HasSavedSelections)
+                                {
+                                        SelectionManager.Instance.RestoreSelections(broker);
+                                }
+                                ModeManager.Instance.EnterNormal(view, broker);
+                                return true;
+                        }
 
 			// In normal mode, also cancel 'esc' keys as that would clear multiple selections.
 			// This prevents Visual Studio's default behavior of collapsing all carets to one.

--- a/VsHelix/EscapeKeyHandler.cs
+++ b/VsHelix/EscapeKeyHandler.cs
@@ -31,12 +31,12 @@ namespace VsHelix
 
 		public bool ExecuteCommand(EscapeKeyCommandArgs args, CommandExecutionContext context)
 		{
-                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
-                        {
-                                var view = args.TextView;
-                                _completionBroker.DismissAllSessions(view);
-                                // Get the TextView from the command arguments (args), not the context.
-                                var broker = view.GetMultiSelectionBroker();
+			if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
+			{
+				var view = args.TextView;
+				_completionBroker.DismissAllSessions(view);
+				// Get the TextView from the command arguments (args), not the context.
+				var broker = view.GetMultiSelectionBroker();
 
 				// Check if the SelectionManager has selections waiting to be restored.
 				if (SelectionManager.Instance.HasSavedSelections)
@@ -46,20 +46,20 @@ namespace VsHelix
 				}
 
 				// Now that the selection is handled, switch the mode.
-                                ModeManager.Instance.EnterNormal(view, broker);
-                                return true; // Command was handled.
-                        }
-                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search)
-                        {
-                                var view = args.TextView;
-                                var broker = view.GetMultiSelectionBroker();
-                                if (SelectionManager.Instance.HasSavedSelections)
-                                {
-                                        SelectionManager.Instance.RestoreSelections(broker);
-                                }
-                                ModeManager.Instance.EnterNormal(view, broker);
-                                return true;
-                        }
+				ModeManager.Instance.EnterNormal(view, broker);
+				return true; // Command was handled.
+			}
+			else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search)
+			{
+				var view = args.TextView;
+				var broker = view.GetMultiSelectionBroker();
+				if (SelectionManager.Instance.HasSavedSelections)
+				{
+					SelectionManager.Instance.RestoreSelections(broker);
+				}
+				ModeManager.Instance.EnterNormal(view, broker);
+				return true;
+			}
 
 			// In normal mode, also cancel 'esc' keys as that would clear multiple selections.
 			// This prevents Visual Studio's default behavior of collapsing all carets to one.

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -22,22 +22,34 @@ namespace VsHelix
 		public static ModeManager Instance => lazyInstance.Value;
 
 		// --- Your existing class members ---
-		public enum EditorMode { Normal, Insert }
-		public EditorMode Current { get; private set; } = EditorMode.Normal;
+                public enum EditorMode { Normal, Insert, Search }
+                public EditorMode Current { get; private set; } = EditorMode.Normal;
 
-		public void EnterInsert(ITextView view, IMultiSelectionBroker broker)
-		{
-			Current = EditorMode.Insert;
-			StatusBarHelper.ShowMode(Current);
-			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, false);
-		}
+                private SearchMode? _searchMode;
+                public SearchMode? Search => _searchMode;
 
-		public void EnterNormal(ITextView view, IMultiSelectionBroker broker)
-		{
-			Current = EditorMode.Normal;
-			StatusBarHelper.ShowMode(Current);
-			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);  // block caret
+                public void EnterInsert(ITextView view, IMultiSelectionBroker broker)
+                {
+                        Current = EditorMode.Insert;
+                        StatusBarHelper.ShowMode(Current);
+                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, false);
+                }
 
-		}
+                public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
+                {
+                        Current = EditorMode.Search;
+                        _searchMode = new SearchMode(selectAll, view, broker, domain);
+                        StatusBarHelper.ShowMode(Current);
+                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
+                }
+
+                public void EnterNormal(ITextView view, IMultiSelectionBroker broker)
+                {
+                        Current = EditorMode.Normal;
+                        _searchMode = null;
+                        StatusBarHelper.ShowMode(Current);
+                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);  // block caret
+
+                }
 	}
 }

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -22,34 +22,34 @@ namespace VsHelix
 		public static ModeManager Instance => lazyInstance.Value;
 
 		// --- Your existing class members ---
-                public enum EditorMode { Normal, Insert, Search }
-                public EditorMode Current { get; private set; } = EditorMode.Normal;
+		public enum EditorMode { Normal, Insert, Search }
+		public EditorMode Current { get; private set; } = EditorMode.Normal;
 
-                private SearchMode? _searchMode;
-                public SearchMode? Search => _searchMode;
+		private SearchMode? _searchMode;
+		public SearchMode? Search => _searchMode;
 
-                public void EnterInsert(ITextView view, IMultiSelectionBroker broker)
-                {
-                        Current = EditorMode.Insert;
-                        StatusBarHelper.ShowMode(Current);
-                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, false);
-                }
+		public void EnterInsert(ITextView view, IMultiSelectionBroker broker)
+		{
+			Current = EditorMode.Insert;
+			StatusBarHelper.ShowMode(Current);
+			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, false);
+		}
 
-                public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
-                {
-                        Current = EditorMode.Search;
-                        _searchMode = new SearchMode(selectAll, view, broker, domain);
-                        StatusBarHelper.ShowMode(Current);
-                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
-                }
+		public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
+		{
+			Current = EditorMode.Search;
+			_searchMode = new SearchMode(selectAll, view, broker, domain);
+			StatusBarHelper.ShowMode(Current);
+			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
+		}
 
-                public void EnterNormal(ITextView view, IMultiSelectionBroker broker)
-                {
-                        Current = EditorMode.Normal;
-                        _searchMode = null;
-                        StatusBarHelper.ShowMode(Current);
-                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);  // block caret
+		public void EnterNormal(ITextView view, IMultiSelectionBroker broker)
+		{
+			Current = EditorMode.Normal;
+			_searchMode = null;
+			StatusBarHelper.ShowMode(Current);
+			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);  // block caret
 
-                }
+		}
 	}
 }

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -1,8 +1,10 @@
 ﻿using System;
-using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Extensibility.Editor;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
 
 namespace VsHelix
 {
@@ -28,6 +30,15 @@ namespace VsHelix
 		private SearchMode? _searchMode;
 		public SearchMode? Search => _searchMode;
 
+		public List<ITrackingSpan> LastSearchSpans { get; set; }
+
+		private ITextSearchService2 GetSearchService()
+		{
+			ThreadHelper.ThrowIfNotOnUIThread();
+			var componentModel = (IComponentModel)ServiceProvider.GlobalProvider.GetService(typeof(SComponentModel));
+			return componentModel.GetService<ITextSearchService2>();
+		}
+
 		public void EnterInsert(ITextView view, IMultiSelectionBroker broker)
 		{
 			Current = EditorMode.Insert;
@@ -38,7 +49,7 @@ namespace VsHelix
 		public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
 		{
 			Current = EditorMode.Search;
-			_searchMode = new SearchMode(selectAll, view, broker, domain);
+			_searchMode = new SearchMode(selectAll, view, broker, domain, GetSearchService());
 			StatusBarHelper.ShowMode(Current);
 			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
 		}

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Text.Json;  // For JSON serialization
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Input;
-using System.Text;
 using Microsoft.VisualStudio.Extensibility.Editor;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -12,7 +13,6 @@ using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Formatting;
 using Microsoft.VisualStudio.Text.Operations;
-using System.Text.Json;  // For JSON serialization
 
 namespace VsHelix
 {
@@ -146,32 +146,32 @@ namespace VsHelix
 				ModeManager.Instance.EnterInsert(view, broker);
 				return true;
 			};
-                        _commandMap['O'] = (args, view, broker, ops) =>
-                        {
-                                // Open a new line *above* each selection and enter Insert mode.
-                                AddLine(view, broker, ops, above: true);
-                                ModeManager.Instance.EnterInsert(view, broker);
-                                return true;
-                        };
-                        _commandMap['/'] = (args, view, broker, ops) =>
-                        {
-                                SelectionManager.Instance.SaveSelections(broker);
-                                var spans = GetSearchDomain(view, broker);
-                                ModeManager.Instance.EnterSearch(view, broker, false, spans);
-                                return true;
-                        };
-                        _commandMap['s'] = (args, view, broker, ops) =>
-                        {
-                                SelectionManager.Instance.SaveSelections(broker);
-                                var spans = GetSearchDomain(view, broker);
-                                ModeManager.Instance.EnterSearch(view, broker, true, spans);
-                                return true;
-                        };
-                        _commandMap['x'] = (args, view, broker, ops) =>
-                        {
-                                // Extend selection to full lines, or extend linewise selection to the next line.
-                                broker.PerformActionOnAllSelections(sel => ExtendSelectionLinewise(sel, view));
-                                return true;
+			_commandMap['O'] = (args, view, broker, ops) =>
+			{
+				// Open a new line *above* each selection and enter Insert mode.
+				AddLine(view, broker, ops, above: true);
+				ModeManager.Instance.EnterInsert(view, broker);
+				return true;
+			};
+			_commandMap['/'] = (args, view, broker, ops) =>
+			{
+				SelectionManager.Instance.SaveSelections(broker);
+				var spans = GetSearchDomain(view, broker);
+				ModeManager.Instance.EnterSearch(view, broker, false, spans);
+				return true;
+			};
+			_commandMap['s'] = (args, view, broker, ops) =>
+			{
+				SelectionManager.Instance.SaveSelections(broker);
+				var spans = GetSearchDomain(view, broker);
+				ModeManager.Instance.EnterSearch(view, broker, true, spans);
+				return true;
+			};
+			_commandMap['x'] = (args, view, broker, ops) =>
+			{
+				// Extend selection to full lines, or extend linewise selection to the next line.
+				broker.PerformActionOnAllSelections(sel => ExtendSelectionLinewise(sel, view));
+				return true;
 			};
 			_commandMap['y'] = (args, view, broker, ops) =>
 			{
@@ -378,8 +378,8 @@ namespace VsHelix
 		/// <summary>
 		/// Adds a new caret below the last selection, aligning it vertically with the original selection’s start/end.
 		/// </summary>
-                private void AddCaretBelowLastSelection(ITextView view, IMultiSelectionBroker broker)
-                {
+		private void AddCaretBelowLastSelection(ITextView view, IMultiSelectionBroker broker)
+		{
 			// Find the bottom-most selection (last in document order).
 			var bottomSelection = broker.AllSelections
 										.OrderByDescending(s => s.End.Position.GetContainingLine().LineNumber)
@@ -398,67 +398,25 @@ namespace VsHelix
 			{
 				// For simplicity, only duplicate carets for single-line selections.
 				return;
-                }
+			}
 
-                private System.Collections.Generic.List<SnapshotSpan> GetSearchDomain(ITextView view, IMultiSelectionBroker broker)
-                {
-                        var spans = new System.Collections.Generic.List<SnapshotSpan>();
-                        foreach (var sel in broker.AllSelections)
-                        {
-                                if (!sel.IsEmpty)
-                                {
-                                        spans.Add(new SnapshotSpan(sel.Start.Position, sel.End.Position));
-                                }
-                        }
-                        if (spans.Count == 0)
-                        {
-                                spans.Add(new SnapshotSpan(view.TextSnapshot, 0, view.TextSnapshot.Length));
-                        }
-                        return spans;
-                }
+		}
 
-			// Get original line text and compute expanded (tab-expanded) text length for alignment.
-			string originalLineText = startLine.GetText();
-			string expandedText = originalLineText.Replace("\t", new string(' ', view.Options.GetTabSize()));
-
-			// Calculate visual offsets of selection start and end within the line (accounting for tabs and virtual spaces).
-			int startOffset = CalculateExpandedOffset(originalLineText.Substring(0, startPoint.Position - startLine.Start), view.Options.GetTabSize());
-			int endOffset = CalculateExpandedOffset(originalLineText.Substring(0, endPoint.Position - startLine.Start), view.Options.GetTabSize());
-			// Include virtual space in the offset calculations.
-			startOffset += startPoint.VirtualSpaces;
-			endOffset += endPoint.VirtualSpaces;
-
-			// Find a line below that has enough length to accommodate the selection at these offsets.
-			int nextLineNumber = endLine.LineNumber + 1;
-			ITextSnapshotLine targetLine = null;
-			int requiredOffset = Math.Max(startOffset, endOffset);
-			while (nextLineNumber < snapshot.LineCount)
+		private System.Collections.Generic.List<SnapshotSpan> GetSearchDomain(ITextView view, IMultiSelectionBroker broker)
+		{
+			var spans = new System.Collections.Generic.List<SnapshotSpan>();
+			foreach (var sel in broker.AllSelections)
 			{
-				var candidateLine = snapshot.GetLineFromLineNumber(nextLineNumber);
-				int candidateLength = CalculateExpandedOffset(candidateLine.GetText(), view.Options.GetTabSize());
-				if (candidateLength >= requiredOffset)
+				if (!sel.IsEmpty)
 				{
-					targetLine = candidateLine;
-					break;
+					spans.Add(new SnapshotSpan(sel.Start.Position, sel.End.Position));
 				}
-				nextLineNumber++;
 			}
-			if (targetLine == null)
+			if (spans.Count == 0)
 			{
-				// No suitable line found below; cannot add a caret aligned to the selection.
-				return;
+				spans.Add(new SnapshotSpan(view.TextSnapshot, 0, view.TextSnapshot.Length));
 			}
-
-			// Create points on the target line corresponding to the original selection's start/end visual offsets.
-			var newStartPoint = CreatePointAtVisualOffset(targetLine, startOffset, view.Options.GetTabSize());
-			var newEndPoint = CreatePointAtVisualOffset(targetLine, endOffset, view.Options.GetTabSize());
-
-			// Form a new selection on the target line with the same orientation (direction) as the original.
-			var newSelection = bottomSelection.IsReversed
-				? new Microsoft.VisualStudio.Text.Selection(newEndPoint, newStartPoint)   // reversed selection
-				: new Microsoft.VisualStudio.Text.Selection(newStartPoint, newEndPoint);  // forward selection
-
-			broker.AddSelection(newSelection);
+			return spans;
 		}
 
 		/// <summary>

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -266,6 +266,8 @@ namespace VsHelix
 			if (lastSpans == null || lastSpans.Count == 0) return;
 
 			var snapshot = view.TextSnapshot;
+			if (snapshot == null) return;  // Prevent crash if snapshot is unexpectedly null
+
 			var orderedSpans = lastSpans.Select(ts => ts.GetSpan(snapshot)).OrderBy(s => s.Start.Position).ToList();
 
 			var currentPos = view.Caret.Position.BufferPosition.Position;
@@ -285,9 +287,8 @@ namespace VsHelix
 			if (target.HasValue)
 			{
 				broker.ClearSecondarySelections();
-				view.Selection.Select(target.Value, false);
-				view.Caret.MoveTo(target.Value.Start);
-				// Optional: Ensure visible
+				view.Selection.Select(target.Value, true);  // Reversed=true to place caret at start
+															// Optional: Ensure visible
 				view.DisplayTextLineContainingBufferPosition(target.Value.Start, 0, ViewRelativePosition.Top);
 			}
 		}

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -167,6 +167,8 @@ namespace VsHelix
 				ModeManager.Instance.EnterSearch(view, broker, true, spans);
 				return true;
 			};
+			_commandMap['n'] = (args, view, broker, ops) => { CycleMatch(true, view, broker); return true; };
+			_commandMap['N'] = (args, view, broker, ops) => { CycleMatch(false, view, broker); return true; };
 			_commandMap['x'] = (args, view, broker, ops) =>
 			{
 				// Extend selection to full lines, or extend linewise selection to the next line.
@@ -256,6 +258,38 @@ namespace VsHelix
 				ModeManager.Instance.EnterInsert(view, broker);
 			}
 			return true;
+		}
+
+		private void CycleMatch(bool forward, ITextView view, IMultiSelectionBroker broker)
+		{
+			var lastSpans = ModeManager.Instance.LastSearchSpans;
+			if (lastSpans == null || lastSpans.Count == 0) return;
+
+			var snapshot = view.TextSnapshot;
+			var orderedSpans = lastSpans.Select(ts => ts.GetSpan(snapshot)).OrderBy(s => s.Start.Position).ToList();
+
+			var currentPos = view.Caret.Position.BufferPosition.Position;
+
+			SnapshotSpan? target = null;
+			if (forward)
+			{
+				target = orderedSpans.FirstOrDefault(s => s.Start.Position > currentPos);
+				if (!target.HasValue) target = orderedSpans.First();
+			}
+			else
+			{
+				target = orderedSpans.LastOrDefault(s => s.Start.Position < currentPos);
+				if (!target.HasValue) target = orderedSpans.Last();
+			}
+
+			if (target.HasValue)
+			{
+				broker.ClearSecondarySelections();
+				view.Selection.Select(target.Value, false);
+				view.Caret.MoveTo(target.Value.Start);
+				// Optional: Ensure visible
+				view.DisplayTextLineContainingBufferPosition(target.Value.Start, 0, ViewRelativePosition.Top);
+			}
 		}
 
 		/// <summary>

--- a/VsHelix/SearchMode.cs
+++ b/VsHelix/SearchMode.cs
@@ -8,122 +8,122 @@ using Microsoft.VisualStudio.Text.Operations;
 
 namespace VsHelix
 {
-		internal sealed class SearchMode : IInputMode
-		{
+	public sealed class SearchMode : IInputMode
+	{
 		private readonly bool _selectAll;
 		private readonly ITextView _view;
 		private readonly IMultiSelectionBroker _broker;
 		private readonly List<SnapshotSpan> _domain;
 		private readonly SnapshotPoint _start;
 		private string _query = string.Empty;
-		
+
 		public SearchMode(bool selectAll, ITextView view, IMultiSelectionBroker broker, List<SnapshotSpan> domain)
 		{
-		_selectAll = selectAll;
-		_view = view;
-		_broker = broker;
-		_domain = domain;
-		_start = view.Caret.Position.BufferPosition;
-		UpdateStatus();
+			_selectAll = selectAll;
+			_view = view;
+			_broker = broker;
+			_domain = domain;
+			_start = view.Caret.Position.BufferPosition;
+			UpdateStatus();
 		}
-		
+
 		public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
 		{
-		char ch = args.TypedChar;
-		if (!char.IsControl(ch))
-		{
-		_query += ch;
-		UpdateMatches();
+			char ch = args.TypedChar;
+			if (!char.IsControl(ch))
+			{
+				_query += ch;
+				UpdateMatches();
+			}
+			return true;
 		}
-		return true;
-		}
-		
+
 		public void HandleBackspace()
 		{
-		if (_query.Length > 0)
-		{
-		_query = _query.Substring(0, _query.Length - 1);
-		UpdateMatches();
+			if (_query.Length > 0)
+			{
+				_query = _query.Substring(0, _query.Length - 1);
+				UpdateMatches();
+			}
 		}
-		}
-		
+
 		public void Finish()
 		{
-		if (!_selectAll)
-		{
-		_broker.ClearSecondarySelections();
+			if (!_selectAll)
+			{
+				_broker.ClearSecondarySelections();
+			}
+			ModeManager.Instance.EnterNormal(_view, _broker);
 		}
-		ModeManager.Instance.EnterNormal(_view, _broker);
-		}
-		
+
 		private void UpdateStatus()
 		{
-		StatusBarHelper.ShowMode(ModeManager.EditorMode.Search, _query);
+			StatusBarHelper.ShowMode(ModeManager.EditorMode.Search, _query);
 		}
-		
+
 		private void UpdateMatches()
 		{
-		_broker.ClearSecondarySelections();
-		
-		if (string.IsNullOrEmpty(_query))
-		{
-		_view.Caret.MoveTo(_start);
-		_view.Selection.Clear();
-		UpdateStatus();
-		return;
+			_broker.ClearSecondarySelections();
+
+			if (string.IsNullOrEmpty(_query))
+			{
+				_view.Caret.MoveTo(_start);
+				_view.Selection.Clear();
+				UpdateStatus();
+				return;
+			}
+
+			Regex regex;
+			try
+			{
+				regex = new Regex(_query);
+			}
+			catch
+			{
+				UpdateStatus();
+				return;
+			}
+
+			var matches = new List<SnapshotSpan>();
+			foreach (var span in _domain)
+			{
+				string text = span.GetText();
+				foreach (Match m in regex.Matches(text))
+				{
+					var start = span.Start + m.Index;
+					var matchSpan = new SnapshotSpan(start, m.Length);
+					matches.Add(matchSpan);
+				}
+			}
+
+			if (matches.Count == 0)
+			{
+				UpdateStatus();
+				return;
+			}
+
+			matches.Sort((a, b) => a.Start.Position.CompareTo(b.Start.Position));
+
+			SnapshotSpan primary = matches[0];
+			foreach (var m in matches)
+			{
+				if (m.Start >= _start)
+				{
+					primary = m;
+					break;
+				}
+			}
+
+			_view.Selection.Select(primary, false);
+			foreach (var m in matches)
+			{
+				if (m != primary)
+				{
+					_broker.AddSelection(new Microsoft.VisualStudio.Text.Selection(m));
+				}
+			}
+
+			UpdateStatus();
 		}
-		
-		Regex regex;
-		try
-		{
-		regex = new Regex(_query);
-		}
-		catch
-		{
-		UpdateStatus();
-		return;
-		}
-		
-		var matches = new List<SnapshotSpan>();
-		foreach (var span in _domain)
-		{
-		string text = span.GetText();
-		foreach (Match m in regex.Matches(text))
-		{
-		var start = span.Start + m.Index;
-		var matchSpan = new SnapshotSpan(start, m.Length);
-		matches.Add(matchSpan);
-		}
-		}
-		
-		if (matches.Count == 0)
-		{
-		UpdateStatus();
-		return;
-		}
-		
-		matches.Sort((a, b) => a.Start.Position.CompareTo(b.Start.Position));
-		
-		SnapshotSpan primary = matches[0];
-		foreach (var m in matches)
-		{
-		if (m.Start >= _start)
-		{
-		primary = m;
-		break;
-		}
-		}
-		
-		_view.Selection.Select(primary, false);
-		foreach (var m in matches)
-		{
-		if (m != primary)
-		{
-		_broker.AddSelection(new Selection(m));
-		}
-		}
-		
-		UpdateStatus();
-		}
-		}
-		}
+	}
+}

--- a/VsHelix/SearchMode.cs
+++ b/VsHelix/SearchMode.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Extensibility.Editor;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Text.Operations;
+
+namespace VsHelix
+{
+		internal sealed class SearchMode : IInputMode
+		{
+		private readonly bool _selectAll;
+		private readonly ITextView _view;
+		private readonly IMultiSelectionBroker _broker;
+		private readonly List<SnapshotSpan> _domain;
+		private readonly SnapshotPoint _start;
+		private string _query = string.Empty;
+		
+		public SearchMode(bool selectAll, ITextView view, IMultiSelectionBroker broker, List<SnapshotSpan> domain)
+		{
+		_selectAll = selectAll;
+		_view = view;
+		_broker = broker;
+		_domain = domain;
+		_start = view.Caret.Position.BufferPosition;
+		UpdateStatus();
+		}
+		
+		public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+		{
+		char ch = args.TypedChar;
+		if (!char.IsControl(ch))
+		{
+		_query += ch;
+		UpdateMatches();
+		}
+		return true;
+		}
+		
+		public void HandleBackspace()
+		{
+		if (_query.Length > 0)
+		{
+		_query = _query.Substring(0, _query.Length - 1);
+		UpdateMatches();
+		}
+		}
+		
+		public void Finish()
+		{
+		if (!_selectAll)
+		{
+		_broker.ClearSecondarySelections();
+		}
+		ModeManager.Instance.EnterNormal(_view, _broker);
+		}
+		
+		private void UpdateStatus()
+		{
+		StatusBarHelper.ShowMode(ModeManager.EditorMode.Search, _query);
+		}
+		
+		private void UpdateMatches()
+		{
+		_broker.ClearSecondarySelections();
+		
+		if (string.IsNullOrEmpty(_query))
+		{
+		_view.Caret.MoveTo(_start);
+		_view.Selection.Clear();
+		UpdateStatus();
+		return;
+		}
+		
+		Regex regex;
+		try
+		{
+		regex = new Regex(_query);
+		}
+		catch
+		{
+		UpdateStatus();
+		return;
+		}
+		
+		var matches = new List<SnapshotSpan>();
+		foreach (var span in _domain)
+		{
+		string text = span.GetText();
+		foreach (Match m in regex.Matches(text))
+		{
+		var start = span.Start + m.Index;
+		var matchSpan = new SnapshotSpan(start, m.Length);
+		matches.Add(matchSpan);
+		}
+		}
+		
+		if (matches.Count == 0)
+		{
+		UpdateStatus();
+		return;
+		}
+		
+		matches.Sort((a, b) => a.Start.Position.CompareTo(b.Start.Position));
+		
+		SnapshotSpan primary = matches[0];
+		foreach (var m in matches)
+		{
+		if (m.Start >= _start)
+		{
+		primary = m;
+		break;
+		}
+		}
+		
+		_view.Selection.Select(primary, false);
+		foreach (var m in matches)
+		{
+		if (m != primary)
+		{
+		_broker.AddSelection(new Selection(m));
+		}
+		}
+		
+		UpdateStatus();
+		}
+		}
+		}

--- a/VsHelix/SearchMode.cs
+++ b/VsHelix/SearchMode.cs
@@ -188,7 +188,11 @@ namespace VsHelix
 			// Clear highlights
 			_highlighter.UpdateHighlights(Enumerable.Empty<SnapshotSpan>());
 
-			if (!_selectAllMatches)
+			if (_selectAllMatches)
+			{
+				SelectionManager.Instance.ClearSelections();
+			}
+			else
 			{
 				_broker.ClearSecondarySelections();
 			}
@@ -254,16 +258,18 @@ namespace VsHelix
 			}
 
 			var primary = firstAfterStart ?? matches[0];
-			_view.Selection.Select(primary, false);
+			_view.Selection.Select(primary, true);  // Reversed=true to place caret at start
 
 			if (_selectAllMatches)
 			{
+				List<Microsoft.VisualStudio.Text.Selection> selections = new List<Microsoft.VisualStudio.Text.Selection>();
 				foreach (var m in matches)
 				{
-					if (m != primary)
-					{
-						_broker.AddSelection(new Microsoft.VisualStudio.Text.Selection(new VirtualSnapshotSpan(m)));
-					}
+					_broker.AddSelection(new Microsoft.VisualStudio.Text.Selection(new VirtualSnapshotSpan(m), true));  // Reversed=true	
+				}
+				if (selections.Count > 0)
+				{
+					_broker.SetSelectionRange(selections, selections.First());
 				}
 			}
 

--- a/VsHelix/SearchMode.cs
+++ b/VsHelix/SearchMode.cs
@@ -1,29 +1,158 @@
+// Updated SearchMode.cs (including the tagger classes as before)
+using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using Microsoft.VisualStudio.Extensibility.Editor;
+using System.ComponentModel.Composition;
+using System.Linq;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Utilities;
 
 namespace VsHelix
 {
+	// New class: Define the highlight format (exported for the editor to recognize)
+	[Export(typeof(EditorFormatDefinition))]
+	[Name("MarkerFormatDefinition/SearchHighlightFormatDefinition")]
+	[UserVisible(true)]
+	internal class SearchHighlightFormatDefinition : MarkerFormatDefinition
+	{
+		public SearchHighlightFormatDefinition()
+		{
+			this.BackgroundColor = System.Windows.Media.Colors.LightYellow;
+			this.DisplayName = "Search Highlight";
+			this.ZOrder = 2; // Adjust z-order to appear behind selections if needed
+		}
+	}
+
+	// New class: The tag type for search highlights
+	internal class SearchHighlightTag : TextMarkerTag
+	{
+		public SearchHighlightTag() : base("MarkerFormatDefinition/SearchHighlightFormatDefinition") { }
+	}
+
+	// New class: The tagger that provides highlight tags based on provided spans
+	internal class SearchHighlightTagger : ITagger<SearchHighlightTag>
+	{
+		private readonly ITextView _view;
+		private readonly ITextBuffer _buffer;
+		private NormalizedSnapshotSpanCollection _highlightSpans;
+		private readonly object _lock = new object();
+
+		public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
+
+		public SearchHighlightTagger(ITextView view, ITextBuffer buffer)
+		{
+			_view = view;
+			_buffer = buffer;
+			_highlightSpans = new NormalizedSnapshotSpanCollection();
+		}
+
+		public IEnumerable<ITagSpan<SearchHighlightTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+		{
+			if (spans.Count == 0 || _highlightSpans == null || _highlightSpans.Count == 0)
+				yield break;
+
+			var currentHighlights = _highlightSpans;
+
+			// Translate to the requested snapshot if necessary
+			if (currentHighlights[0].Snapshot != spans[0].Snapshot)
+			{
+				currentHighlights = new NormalizedSnapshotSpanCollection(
+					currentHighlights.Select(s => s.TranslateTo(spans[0].Snapshot, SpanTrackingMode.EdgeExclusive)));
+			}
+
+			// Find overlapping spans
+			var intersecting = NormalizedSnapshotSpanCollection.Overlap(currentHighlights, spans);
+			foreach (var intersectSpan in intersecting)
+			{
+				yield return new TagSpan<SearchHighlightTag>(intersectSpan, new SearchHighlightTag());
+			}
+		}
+
+		public void UpdateHighlights(IEnumerable<SnapshotSpan> newHighlights)
+		{
+			var snapshot = _buffer.CurrentSnapshot;
+			var newNorm = new NormalizedSnapshotSpanCollection(newHighlights.Where(s => s.Length > 0));
+
+			lock (_lock)
+			{
+				if (NormalizedSnapshotSpanCollection.Equals(_highlightSpans, newNorm))
+					return;
+
+				var oldSpans = _highlightSpans;
+				_highlightSpans = newNorm;
+
+				// Raise TagsChanged for the entire buffer or the union of old and new spans
+				SnapshotSpan changedSpan = new SnapshotSpan(snapshot, 0, snapshot.Length);
+				if (oldSpans != null && oldSpans.Count > 0 && newNorm.Count > 0)
+				{
+					var union = NormalizedSnapshotSpanCollection.Union(oldSpans, newNorm);
+					if (union.Count > 0)
+					{
+						changedSpan = new SnapshotSpan(union.First().Start, union.Last().End);
+					}
+				}
+				else if (oldSpans != null && oldSpans.Count > 0)
+				{
+					changedSpan = new SnapshotSpan(oldSpans.First().Start, oldSpans.Last().End);
+				}
+				else if (newNorm.Count > 0)
+				{
+					changedSpan = new SnapshotSpan(newNorm.First().Start, newNorm.Last().End);
+				}
+
+				TagsChanged?.Invoke(this, new SnapshotSpanEventArgs(changedSpan));
+			}
+		}
+	}
+
+	// New class: Provider for the tagger (exported via MEF)
+	[Export(typeof(IViewTaggerProvider))]
+	[ContentType("text")]
+	[TagType(typeof(SearchHighlightTag))]
+	internal class SearchHighlightTaggerProvider : IViewTaggerProvider
+	{
+		public ITagger<T> CreateTagger<T>(ITextView textView, ITextBuffer buffer) where T : ITag
+		{
+			if (textView == null || buffer == null)
+				return null;
+
+			// Create the tagger and store it in view properties for easy access
+			var tagger = new SearchHighlightTagger(textView, buffer);
+			textView.Properties["SearchHighlightTagger"] = tagger;
+			return tagger as ITagger<T>;
+		}
+	}
+
+	// Updated SearchMode class
 	public sealed class SearchMode : IInputMode
 	{
-		private readonly bool _selectAll;
+		private readonly bool _selectAllMatches;
 		private readonly ITextView _view;
 		private readonly IMultiSelectionBroker _broker;
+		private readonly ITextBuffer _buffer;
 		private readonly List<SnapshotSpan> _domain;
 		private readonly SnapshotPoint _start;
 		private string _query = string.Empty;
+		private readonly ITextSearchService2 _searchService;
+		private readonly SearchHighlightTagger _highlighter;
 
-		public SearchMode(bool selectAll, ITextView view, IMultiSelectionBroker broker, List<SnapshotSpan> domain)
+		public SearchMode(bool selectAll, ITextView view, IMultiSelectionBroker broker, List<SnapshotSpan> domain, ITextSearchService2 searchService)
 		{
-			_selectAll = selectAll;
+			_selectAllMatches = selectAll;
 			_view = view;
 			_broker = broker;
+			_buffer = view.TextBuffer;
 			_domain = domain;
 			_start = view.Caret.Position.BufferPosition;
+			_searchService = searchService;
+
+			// Get the highlighter tagger from view properties
+			_highlighter = _view.Properties.GetProperty<SearchHighlightTagger>("SearchHighlightTagger");
+
 			UpdateStatus();
 		}
 
@@ -49,7 +178,17 @@ namespace VsHelix
 
 		public void Finish()
 		{
-			if (!_selectAll)
+			// Store matches for cycling if not select-all mode and there are matches
+			var matches = GetCurrentMatches(); // Helper to get matches without recalculating
+			if (!_selectAllMatches && matches.Count > 0 && !string.IsNullOrEmpty(_query))
+			{
+				ModeManager.Instance.LastSearchSpans = matches.Select(m => _buffer.CurrentSnapshot.CreateTrackingSpan(m, SpanTrackingMode.EdgeInclusive)).ToList();
+			}
+
+			// Clear highlights
+			_highlighter.UpdateHighlights(Enumerable.Empty<SnapshotSpan>());
+
+			if (!_selectAllMatches)
 			{
 				_broker.ClearSecondarySelections();
 			}
@@ -60,6 +199,7 @@ namespace VsHelix
 		{
 			StatusBarHelper.ShowMode(ModeManager.EditorMode.Search, _query);
 		}
+
 		private void UpdateMatches()
 		{
 			_broker.ClearSecondarySelections();
@@ -68,53 +208,44 @@ namespace VsHelix
 			{
 				_view.Caret.MoveTo(_start);
 				_view.Selection.Clear();
+				_highlighter.UpdateHighlights(Enumerable.Empty<SnapshotSpan>());
 				UpdateStatus();
 				return;
 			}
 
-			Regex regex;
-			try
-			{
-				regex = new Regex(_query);
-			}
-			catch
-			{
-				UpdateStatus();
-				return;
-			}
+			var findOptions = FindOptions.UseRegularExpressions | FindOptions.MatchCase;
 
 			var matches = new List<SnapshotSpan>();
 			SnapshotSpan? firstAfterStart = null;
 
 			foreach (var domainSpan in _domain)
 			{
-				var snapshot = domainSpan.Snapshot;
-				var startLineNum = domainSpan.Start.GetContainingLine().LineNumber;
-				var endLineNum = domainSpan.End.GetContainingLine().LineNumber;
-
-				for (int lineNum = startLineNum; lineNum <= endLineNum; lineNum++)
+				try
 				{
-					var line = snapshot.GetLineFromLineNumber(lineNum);
-					int lineStart = (lineNum == startLineNum) ? Math.Max(0, domainSpan.Start.Position - line.Start.Position) : 0;
-					int lineEnd = (lineNum == endLineNum) ? domainSpan.End.Position - line.Start.Position : line.Length;
-
-					if (lineStart >= lineEnd) continue; // empty line portion
-
-					string lineText = line.GetText().Substring(lineStart, lineEnd - lineStart);
-
-					foreach (Match m in regex.Matches(lineText))
+					var found = _searchService.FindAll(domainSpan, _query, findOptions);
+					foreach (var span in found)
 					{
-						var matchStartPos = line.Start + lineStart + m.Index;
-						var matchSpan = new SnapshotSpan(matchStartPos, m.Length);
-						matches.Add(matchSpan);
-
-						if (!firstAfterStart.HasValue && matchSpan.Start >= _start)
+						if (span.Length > 0)
 						{
-							firstAfterStart = matchSpan;
+							matches.Add(span);
+							if (!firstAfterStart.HasValue && span.Start >= _start)
+							{
+								firstAfterStart = span;
+							}
 						}
 					}
 				}
+				catch (ArgumentException)
+				{
+					// Invalid regex pattern
+					_highlighter.UpdateHighlights(Enumerable.Empty<SnapshotSpan>());
+					UpdateStatus();
+					return;
+				}
 			}
+
+			// Always update highlights with all matches
+			_highlighter.UpdateHighlights(matches);
 
 			if (matches.Count == 0)
 			{
@@ -122,24 +253,42 @@ namespace VsHelix
 				return;
 			}
 
-			// No sort needed, as matches are collected in document order (lines are sequential)
-
-			SnapshotSpan primary = firstAfterStart ?? matches[0]; // wrap to first if none after start
-
+			var primary = firstAfterStart ?? matches[0];
 			_view.Selection.Select(primary, false);
 
-			if (_selectAll)
+			if (_selectAllMatches)
 			{
 				foreach (var m in matches)
 				{
 					if (m != primary)
 					{
-						_broker.AddSelection(new Microsoft.VisualStudio.Text.Selection(m));
+						_broker.AddSelection(new Microsoft.VisualStudio.Text.Selection(new VirtualSnapshotSpan(m)));
 					}
 				}
 			}
 
 			UpdateStatus();
+		}
+
+		// Helper to retrieve current matches (assuming UpdateMatches can be called to cache if needed; for simplicity, recalculate or add caching if performance issue)
+		private List<SnapshotSpan> GetCurrentMatches()
+		{
+			// For now, recalculate; optimize if needed
+			var findOptions = FindOptions.UseRegularExpressions | FindOptions.MatchCase;
+			var matches = new List<SnapshotSpan>();
+			foreach (var domainSpan in _domain)
+			{
+				try
+				{
+					var found = _searchService.FindAll(domainSpan, _query, findOptions);
+					matches.AddRange(found.Where(s => s.Length > 0));
+				}
+				catch (ArgumentException)
+				{
+					return new List<SnapshotSpan>();
+				}
+			}
+			return matches;
 		}
 	}
 }

--- a/VsHelix/SelectionManager.cs
+++ b/VsHelix/SelectionManager.cs
@@ -54,6 +54,14 @@ namespace VsHelix
 		}
 
 		/// <summary>
+		/// Clears any saved selections without restoring them.
+		/// </summary>
+		public void ClearSelections()
+		{
+			selectionsToRestore = null;
+		}
+
+		/// <summary>
 		/// Restores the previously saved selections onto the editor's current text snapshot.
 		/// </summary>
 		/// <param name="broker">The multi-selection broker for the active view.</param>

--- a/VsHelix/StatusBarHelper.cs
+++ b/VsHelix/StatusBarHelper.cs
@@ -3,23 +3,23 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace VsHelix
 {
-    internal static class StatusBarHelper
-    {
-        public static void ShowMode(ModeManager.EditorMode mode, string extra = "")
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            var status = ServiceProvider.GlobalProvider.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
-            var text = mode switch
-            {
-                ModeManager.EditorMode.Normal => "NOR",
-                ModeManager.EditorMode.Insert => "INS",
-                ModeManager.EditorMode.Search => "SCH",
-                _ => mode.ToString().ToUpperInvariant(),
-            };
-            if (!string.IsNullOrEmpty(extra))
-                status?.SetText($"{text} {extra}");
-            else
-                status?.SetText($"{text} ");
-        }
-    }
+	internal static class StatusBarHelper
+	{
+		public static void ShowMode(ModeManager.EditorMode mode, string extra = "")
+		{
+			ThreadHelper.ThrowIfNotOnUIThread();
+			var status = ServiceProvider.GlobalProvider.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
+			var text = mode switch
+			{
+				ModeManager.EditorMode.Normal => "NOR",
+				ModeManager.EditorMode.Insert => "INS",
+				ModeManager.EditorMode.Search => "SCH",
+				_ => mode.ToString().ToUpperInvariant(),
+			};
+			if (!string.IsNullOrEmpty(extra))
+				status?.SetText($"{text} {extra}");
+			else
+				status?.SetText($"{text} ");
+		}
+	}
 }

--- a/VsHelix/StatusBarHelper.cs
+++ b/VsHelix/StatusBarHelper.cs
@@ -5,7 +5,7 @@ namespace VsHelix
 {
     internal static class StatusBarHelper
     {
-        public static void ShowMode(ModeManager.EditorMode mode)
+        public static void ShowMode(ModeManager.EditorMode mode, string extra = "")
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             var status = ServiceProvider.GlobalProvider.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
@@ -13,9 +13,13 @@ namespace VsHelix
             {
                 ModeManager.EditorMode.Normal => "NOR",
                 ModeManager.EditorMode.Insert => "INS",
+                ModeManager.EditorMode.Search => "SCH",
                 _ => mode.ToString().ToUpperInvariant(),
             };
-            status?.SetText($"{text} ");
+            if (!string.IsNullOrEmpty(extra))
+                status?.SetText($"{text} {extra}");
+            else
+                status?.SetText($"{text} ");
         }
     }
 }

--- a/VsHelix/TypeCharFilter.cs
+++ b/VsHelix/TypeCharFilter.cs
@@ -44,14 +44,18 @@ namespace VsHelix
 			var broker = view.GetMultiSelectionBroker();
 			var ops = _editorOperationsFactory.GetEditorOperations(view);
 			
-			if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
-			{
-				return _normalMode.Handle(args, view, broker, ops);
-			}
-			else if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
-			{
-				return _insertMode.Handle(args, view, broker, ops);
-			}
+                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
+                        {
+                                return _normalMode.Handle(args, view, broker, ops);
+                        }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
+                        {
+                                return _insertMode.Handle(args, view, broker, ops);
+                        }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
+                        {
+                                return ModeManager.Instance.Search.Handle(args, view, broker, ops);
+                        }
 
 			return false;
 		}

--- a/VsHelix/TypeCharFilter.cs
+++ b/VsHelix/TypeCharFilter.cs
@@ -43,19 +43,19 @@ namespace VsHelix
 			var view = args.TextView;
 			var broker = view.GetMultiSelectionBroker();
 			var ops = _editorOperationsFactory.GetEditorOperations(view);
-			
-                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
-                        {
-                                return _normalMode.Handle(args, view, broker, ops);
-                        }
-                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
-                        {
-                                return _insertMode.Handle(args, view, broker, ops);
-                        }
-                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
-                        {
-                                return ModeManager.Instance.Search.Handle(args, view, broker, ops);
-                        }
+
+			if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
+			{
+				return _normalMode.Handle(args, view, broker, ops);
+			}
+			else if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
+			{
+				return _insertMode.Handle(args, view, broker, ops);
+			}
+			else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
+			{
+				return ModeManager.Instance.Search.Handle(args, view, broker, ops);
+			}
 
 			return false;
 		}


### PR DESCRIPTION
## Summary
- implement a new `SearchMode` for inline searching
- add `/` and `s` normal mode commands
- show search status in the status bar
- hook up Enter and Backspace handlers
- document search and select commands

## Testing
- `msbuild VsHelix.sln /restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875b0bb09088324aeeca17c2e1e8406