### PR TITLE
Move n/N handling into search mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Press `u` to undo and `U` to redo the last action.
 Pressing <kbd>Esc</kbd> now closes any active IntelliSense sessions before
 returning to normal mode.
 Pressing <kbd>,</kbd> clears all secondary selections, leaving a single cursor.
-Use `s` to select all matches of a regex typed inline. `/` performs an incremental search that highlights matches as you type. Press **Enter** to accept the search or **Esc** to cancel.
+Use `s` to select all matches of a regex typed inline. `/` performs an incremental search that highlights matches as you type. While searching, `n` and `N` jump to the next or previous match. Press **Enter** to accept the search or **Esc** to cancel.

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -30,7 +30,6 @@ namespace VsHelix
 		private SearchMode? _searchMode;
 		public SearchMode? Search => _searchMode;
 
-		public List<ITrackingSpan> LastSearchSpans { get; set; }
 
 		private ITextSearchService2 GetSearchService()
 		{


### PR DESCRIPTION
## Summary
- remove LastSearchSpans tracking
- drop n/N commands from NormalMode
- implement navigation inside SearchMode
- document search navigation
- adjust search mode command map layout

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6875eec7f328832480e97b263c97b5e4