### PR TITLE
Implement match mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ Pressing <kbd>Esc</kbd> now closes any active IntelliSense sessions before
 returning to normal mode.
 Pressing <kbd>,</kbd> clears all secondary selections, leaving a single cursor.
 Use `s` to select all matches of a regex typed inline. `/` performs an incremental search that highlights matches as you type. While searching, `n` and `N` jump to the next or previous match. Press **Enter** to accept the search or **Esc** to cancel.
+Press `m` to manipulate matching pairs. After entering match mode:
+`m` jumps to the matching bracket, `s <char>` surrounds the selection,
+`r <from><to>` replaces the surrounding characters, `d <char>` removes the
+surrounding pair, and `a`/`i <char>` select around or inside a pair.

--- a/VsHelix/EscapeKeyHandler.cs
+++ b/VsHelix/EscapeKeyHandler.cs
@@ -49,17 +49,24 @@ namespace VsHelix
 				ModeManager.Instance.EnterNormal(view, broker);
 				return true; // Command was handled.
 			}
-			else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search)
-			{
-				var view = args.TextView;
-				var broker = view.GetMultiSelectionBroker();
-				if (SelectionManager.Instance.HasSavedSelections)
-				{
-					SelectionManager.Instance.RestoreSelections(broker);
-				}
-				ModeManager.Instance.EnterNormal(view, broker);
-				return true;
-			}
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search)
+                        {
+                                var view = args.TextView;
+                                var broker = view.GetMultiSelectionBroker();
+                                if (SelectionManager.Instance.HasSavedSelections)
+                                {
+                                        SelectionManager.Instance.RestoreSelections(broker);
+                                }
+                                ModeManager.Instance.EnterNormal(view, broker);
+                                return true;
+                        }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Match)
+                        {
+                                var view = args.TextView;
+                                var broker = view.GetMultiSelectionBroker();
+                                ModeManager.Instance.EnterNormal(view, broker);
+                                return true;
+                        }
 
 			// In normal mode, also cancel 'esc' keys as that would clear multiple selections.
 			// This prevents Visual Studio's default behavior of collapsing all carets to one.

--- a/VsHelix/MatchMode.cs
+++ b/VsHelix/MatchMode.cs
@@ -1,0 +1,285 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Extensibility.Editor;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Text.Operations;
+
+namespace VsHelix
+{
+internal sealed class MatchMode : IInputMode
+{
+private readonly ITextView _view;
+private readonly IMultiSelectionBroker _broker;
+
+private enum MatchState { AwaitCommand, Surround, ReplaceFirst, ReplaceSecond, Delete, Around, Inside }
+private MatchState _state = MatchState.AwaitCommand;
+private char _replaceFrom;
+
+private readonly struct BracketPair
+{
+public readonly char Open;
+public readonly char Close;
+public BracketPair(char open, char close)
+{
+Open = open;
+Close = close;
+}
+}
+
+private static readonly IReadOnlyDictionary<char, BracketPair> _pairs = new Dictionary<char, BracketPair>
+{
+['('] = new BracketPair('(', ')'),
+['['] = new BracketPair('[', ']'),
+['{'] = new BracketPair('{', '}'),
+['<'] = new BracketPair('<', '>'),
+['"'] = new BracketPair('"', '"'),
+['\''] = new BracketPair('\'', '\'')
+};
+
+public MatchMode(ITextView view, IMultiSelectionBroker broker)
+{
+_view = view;
+_broker = broker;
+StatusBarHelper.ShowMode(ModeManager.EditorMode.Match);
+}
+
+public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+{
+char ch = args.TypedChar;
+if (char.IsControl(ch))
+return true;
+
+return _state switch
+{
+MatchState.AwaitCommand => HandleCommand(ch),
+MatchState.Surround => ExitAfter(() => SurroundSelections(ch)),
+MatchState.ReplaceFirst => SetReplaceFrom(ch),
+MatchState.ReplaceSecond => ExitAfter(() => ReplaceSurround(_replaceFrom, ch)),
+MatchState.Delete => ExitAfter(() => DeleteSurround(ch)),
+MatchState.Around => ExitAfter(() => SelectTextObject(ch, true)),
+MatchState.Inside => ExitAfter(() => SelectTextObject(ch, false)),
+_ => Exit()
+};
+}
+
+private bool HandleCommand(char ch)
+{
+switch (ch)
+{
+case 'm':
+_broker.PerformActionOnAllSelections(sel => GoToMatchingBracket(sel));
+return Exit();
+case 's':
+_state = MatchState.Surround;
+return true;
+case 'r':
+_state = MatchState.ReplaceFirst;
+return true;
+case 'd':
+_state = MatchState.Delete;
+return true;
+case 'a':
+_state = MatchState.Around;
+return true;
+case 'i':
+_state = MatchState.Inside;
+return true;
+default:
+return Exit();
+}
+}
+
+private bool SetReplaceFrom(char ch)
+{
+_replaceFrom = ch;
+_state = MatchState.ReplaceSecond;
+return true;
+}
+
+private bool ExitAfter(System.Action action)
+{
+action();
+return Exit();
+}
+
+private bool Exit()
+{
+ModeManager.Instance.EnterNormal(_view, _broker);
+return true;
+}
+
+private static bool TryGetPair(char ch, out BracketPair pair)
+=> _pairs.TryGetValue(ch, out pair);
+
+private void GoToMatchingBracket(ISelectionTransformer transformer)
+{
+var pos = transformer.Selection.ActivePoint.Position;
+var snapshot = pos.Snapshot;
+
+if (pos.Position > 0 && TryGetPair(snapshot[pos.Position - 1], out var before) && before.Close != snapshot[pos.Position - 1])
+{
+int match = FindMatch(snapshot, pos.Position - 1, before.Open, before.Close, -1, 0);
+if (match >= 0)
+transformer.MoveTo(new SnapshotPoint(snapshot, match), false, PositionAffinity.Successor);
+return;
+}
+
+if (pos.Position < snapshot.Length && TryGetPair(snapshot[pos.Position], out var after))
+{
+char open = snapshot[pos.Position] == after.Open ? after.Open : after.Close;
+char close = snapshot[pos.Position] == after.Open ? after.Close : after.Open;
+int dir = snapshot[pos.Position] == after.Open ? 1 : -1;
+int match = FindMatch(snapshot, pos.Position, open, close, dir, 0);
+if (match >= 0)
+transformer.MoveTo(new SnapshotPoint(snapshot, match), false, PositionAffinity.Successor);
+}
+}
+
+private static int FindMatch(ITextSnapshot snapshot, int start, char open, char close, int dir, int depth)
+{
+int i = start;
+while (true)
+{
+i += dir;
+if (i < 0 || i >= snapshot.Length)
+return -1;
+char c = snapshot[i];
+if (c == open)
+depth++;
+else if (c == close)
+{
+if (depth == 0)
+return i;
+depth--;
+}
+}
+}
+
+private void SurroundSelections(char ch)
+{
+if (!TryGetPair(ch, out var pair))
+return;
+
+var sels = _broker.AllSelections.OrderByDescending(s => s.Start.Position).ToList();
+using (var edit = _view.TextBuffer.CreateEdit())
+{
+foreach (var sel in sels)
+{
+edit.Insert(sel.End.Position, pair.Close.ToString());
+edit.Insert(sel.Start.Position, pair.Open.ToString());
+}
+edit.Apply();
+}
+
+var snapshot = _view.TextBuffer.CurrentSnapshot;
+var newSelections = new List<Selection>();
+foreach (var sel in sels)
+{
+var start = new SnapshotPoint(snapshot, sel.Start.Position);
+var end = new SnapshotPoint(snapshot, sel.End.Position + 2);
+newSelections.Add(new Selection(new VirtualSnapshotSpan(start, end), sel.IsReversed));
+}
+ApplySelections(newSelections);
+}
+
+private void ReplaceSurround(char from, char to)
+{
+if (!TryGetPair(from, out var fromPair) || !TryGetPair(to, out var toPair))
+return;
+
+var sels = _broker.AllSelections.OrderByDescending(s => s.Start.Position).ToList();
+using (var edit = _view.TextBuffer.CreateEdit())
+{
+foreach (var sel in sels)
+{
+var snapshot = _view.TextBuffer.CurrentSnapshot;
+if (sel.Start.Position == 0 || sel.End.Position >= snapshot.Length)
+continue;
+if (snapshot[sel.Start.Position - 1] == fromPair.Open && snapshot[sel.End.Position] == fromPair.Close)
+{
+edit.Replace(new Span(sel.Start.Position - 1, 1), toPair.Open.ToString());
+edit.Replace(new Span(sel.End.Position, 1), toPair.Close.ToString());
+}
+}
+edit.Apply();
+}
+}
+
+private void DeleteSurround(char ch)
+{
+if (!TryGetPair(ch, out var pair))
+return;
+
+var sels = _broker.AllSelections.OrderByDescending(s => s.Start.Position).ToList();
+using (var edit = _view.TextBuffer.CreateEdit())
+{
+foreach (var sel in sels)
+{
+var snapshot = _view.TextBuffer.CurrentSnapshot;
+if (sel.Start.Position == 0 || sel.End.Position >= snapshot.Length)
+continue;
+if (snapshot[sel.Start.Position - 1] == pair.Open && snapshot[sel.End.Position] == pair.Close)
+{
+edit.Delete(new Span(sel.End.Position, 1));
+edit.Delete(new Span(sel.Start.Position - 1, 1));
+}
+}
+edit.Apply();
+}
+}
+
+private void SelectTextObject(char ch, bool around)
+{
+if (!TryGetPair(ch, out var pair))
+return;
+
+var snapshot = _view.TextBuffer.CurrentSnapshot;
+var newSelections = new List<Selection>();
+foreach (var sel in _broker.AllSelections)
+{
+int open = FindPrev(snapshot, sel.Start.Position, pair.Open);
+int close = FindNext(snapshot, sel.End.Position, pair.Close);
+if (open >= 0 && close >= 0 && open < close)
+{
+int start = around ? open : open + 1;
+int end = around ? close + 1 : close;
+newSelections.Add(new Selection(new VirtualSnapshotSpan(new SnapshotPoint(snapshot, start), new SnapshotPoint(snapshot, end)), sel.IsReversed));
+}
+else
+{
+newSelections.Add(sel);
+}
+}
+ApplySelections(newSelections);
+}
+
+private static int FindPrev(ITextSnapshot snapshot, int start, char ch)
+{
+for (int i = start - 1; i >= 0; i--)
+if (snapshot[i] == ch)
+return i;
+return -1;
+}
+
+private static int FindNext(ITextSnapshot snapshot, int start, char ch)
+{
+for (int i = start; i < snapshot.Length; i++)
+if (snapshot[i] == ch)
+return i;
+return -1;
+}
+
+private void ApplySelections(IReadOnlyList<Selection> selections)
+{
+if (selections.Count == 0)
+return;
+
+_broker.ClearSecondarySelections();
+_view.Selection.Select(new SnapshotSpan(selections[0].Start.Position, selections[0].End.Position), selections[0].IsReversed);
+foreach (var sel in selections.Skip(1))
+_broker.AddSelection(sel);
+}
+}
+}

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -24,11 +24,13 @@ namespace VsHelix
 		public static ModeManager Instance => lazyInstance.Value;
 
 		// --- Your existing class members ---
-		public enum EditorMode { Normal, Insert, Search }
+                public enum EditorMode { Normal, Insert, Search, Match }
 		public EditorMode Current { get; private set; } = EditorMode.Normal;
 
-		private SearchMode? _searchMode;
-		public SearchMode? Search => _searchMode;
+                private SearchMode? _searchMode;
+                public SearchMode? Search => _searchMode;
+                private MatchMode? _matchMode;
+                public MatchMode? Match => _matchMode;
 
 
 		private ITextSearchService2 GetSearchService()
@@ -45,21 +47,30 @@ namespace VsHelix
 			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, false);
 		}
 
-		public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
-		{
-			Current = EditorMode.Search;
-			_searchMode = new SearchMode(selectAll, view, broker, domain, GetSearchService());
-			StatusBarHelper.ShowMode(Current);
-			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
-		}
+                public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
+                {
+                        Current = EditorMode.Search;
+                        _searchMode = new SearchMode(selectAll, view, broker, domain, GetSearchService());
+                        StatusBarHelper.ShowMode(Current);
+                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
+                }
 
-		public void EnterNormal(ITextView view, IMultiSelectionBroker broker)
-		{
-			Current = EditorMode.Normal;
-			_searchMode = null;
-			StatusBarHelper.ShowMode(Current);
-			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);  // block caret
+                public void EnterMatch(ITextView view, IMultiSelectionBroker broker)
+                {
+                        Current = EditorMode.Match;
+                        _matchMode = new MatchMode(view, broker);
+                        StatusBarHelper.ShowMode(Current);
+                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
+                }
 
-		}
+                public void EnterNormal(ITextView view, IMultiSelectionBroker broker)
+                {
+                        Current = EditorMode.Normal;
+                        _searchMode = null;
+                        _matchMode = null;
+                        StatusBarHelper.ShowMode(Current);
+                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);  // block caret
+
+                }
 	}
 }

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -197,7 +197,12 @@ namespace VsHelix
 				ModeManager.Instance.EnterInsert(view, broker);
 				return true;
 			};
-			_commandMap['/'] = (args, view, broker, ops) =>
+                        _commandMap['m'] = (args, view, broker, ops) =>
+                        {
+                                ModeManager.Instance.EnterMatch(view, broker);
+                                return true;
+                        };
+                        _commandMap['/'] = (args, view, broker, ops) =>
 			{
 				SelectionManager.Instance.SaveSelections(broker);
 				var spans = GetSearchDomain(view, broker);

--- a/VsHelix/StatusBarHelper.cs
+++ b/VsHelix/StatusBarHelper.cs
@@ -13,8 +13,9 @@ namespace VsHelix
 			{
 				ModeManager.EditorMode.Normal => "NOR",
 				ModeManager.EditorMode.Insert => "INS",
-				ModeManager.EditorMode.Search => "SCH",
-				_ => mode.ToString().ToUpperInvariant(),
+                                ModeManager.EditorMode.Search => "SCH",
+                                ModeManager.EditorMode.Match => "MAT",
+                                _ => mode.ToString().ToUpperInvariant(),
 			};
 			if (!string.IsNullOrEmpty(extra))
 				status?.SetText($"{text} {extra}");

--- a/VsHelix/TypeCharFilter.cs
+++ b/VsHelix/TypeCharFilter.cs
@@ -52,10 +52,14 @@ namespace VsHelix
 			{
 				return _insertMode.Handle(args, view, broker, ops);
 			}
-			else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
-			{
-				return ModeManager.Instance.Search.Handle(args, view, broker, ops);
-			}
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
+                        {
+                                return ModeManager.Instance.Search.Handle(args, view, broker, ops);
+                        }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Match && ModeManager.Instance.Match != null)
+                        {
+                                return ModeManager.Instance.Match.Handle(args, view, broker, ops);
+                        }
 
 			return false;
 		}


### PR DESCRIPTION
## Summary
- add match mode for bracket operations
- route typing and Escape to the new mode
- show `MAT` in the status bar when active
- document match commands in README
- refactor `MatchMode` for readability

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_687739a60a788324b17a4a8f239631e7