### PR TITLE
Introduce keymap handling across modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ copies the current selection to the line below while <kbd>Alt</kbd>+`C`
 duplicates the selection on the line above.  Use `o` to open a new line below
 each caret and `O` to open one above.  Both commands switch to insert mode at
 the newly inserted line with the indentation of the surrounding text.
+Commands are resolved using a small Helix-style keymap per mode, allowing
+multi-key sequences to be added in the future.
 Press `p` pastes clipboard text after each selection. When the clipboard content
 ends with a newline it is inserted on its own line; otherwise it is inserted at
 the caret positions. Use `y` to yank the current selections to the clipboard.
@@ -58,7 +60,7 @@ Type a number before any normal-mode command to repeat it that many times.
 Pressing <kbd>Esc</kbd> now closes any active IntelliSense sessions before
 returning to normal mode.
 Pressing <kbd>,</kbd> clears all secondary selections, leaving a single cursor.
-Use `s` to select all matches of a regex typed inline. `/` performs an incremental search that highlights matches as you type. While searching, `n` and `N` jump to the next or previous match. Press **Enter** to accept the search or **Esc** to cancel.
+Use `s` to select all matches of a regex typed inline. `/` performs an incremental search that highlights matches as you type. While searching, `n` and `N` jump to the next or previous match. Press **Enter** to accept the search or **Esc** to cancel. Enter and Backspace are now dispatched through the same keymap as other characters.
 Press `m` to manipulate matching pairs. After entering match mode:
 `m` jumps to the matching bracket, `s <char>` surrounds the selection,
 `r <from><to>` replaces the surrounding characters, `d <char>` removes the

--- a/VsHelix/BackspaceKeyHandler.cs
+++ b/VsHelix/BackspaceKeyHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Extensibility;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
 
 namespace VsHelix
@@ -13,20 +14,34 @@ namespace VsHelix
 	[Name(nameof(BackspaceKeyHandler))]
 	[Order(Before = "Backspace")]
 	[VisualStudioContribution]
-	internal sealed class BackspaceKeyHandler : ICommandHandler<BackspaceKeyCommandArgs>
-	{
-		public string DisplayName => "Helix Backspace Handler";
+        internal sealed class BackspaceKeyHandler : ICommandHandler<BackspaceKeyCommandArgs>
+        {
+                private readonly IEditorOperationsFactoryService _operationsFactory;
 
-		public CommandState GetCommandState(BackspaceKeyCommandArgs args) => CommandState.Available;
+                [ImportingConstructor]
+                public BackspaceKeyHandler(IEditorOperationsFactoryService operationsFactory)
+                {
+                        _operationsFactory = operationsFactory;
+                }
 
-		public bool ExecuteCommand(BackspaceKeyCommandArgs args, CommandExecutionContext context)
-		{
-			if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
-			{
-				ModeManager.Instance.Search.HandleBackspace();
-				return true;
-			}
-			return false;
-		}
-	}
+                public string DisplayName => "Helix Backspace Handler";
+
+                public CommandState GetCommandState(BackspaceKeyCommandArgs args) => CommandState.Available;
+
+                public bool ExecuteCommand(BackspaceKeyCommandArgs args, CommandExecutionContext context)
+                {
+                        var view = args.TextView;
+                        var broker = view.GetMultiSelectionBroker();
+                        var ops = _operationsFactory.GetEditorOperations(view);
+
+                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
+                                return ModeManager.Instance.Search.HandleChar('\b', view, broker, ops);
+                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Match && ModeManager.Instance.Match != null)
+                                return ModeManager.Instance.Match.HandleChar('\b', view, broker, ops);
+                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
+                                return true; // swallow
+
+                        return false;
+                }
+        }
 }

--- a/VsHelix/IInputMode.cs
+++ b/VsHelix/IInputMode.cs
@@ -9,8 +9,8 @@ namespace VsHelix
 	/// <summary>
 	/// Defines the contract for a mode handler.
 	/// </summary>
-	internal interface IInputMode
-	{
-		bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations);
-	}
+       internal interface IInputMode
+       {
+               bool HandleChar(char ch, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations);
+       }
 }

--- a/VsHelix/InsertMode.cs
+++ b/VsHelix/InsertMode.cs
@@ -9,11 +9,11 @@ namespace VsHelix
 	/// <summary>
 	/// Handles key input when in Insert mode.
 	/// </summary>
-	internal sealed class InsertMode : IInputMode
-	{
-		public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
-		{
-			return false;
-		}
-	}
+       internal sealed class InsertMode : IInputMode
+       {
+               public bool HandleChar(char ch, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+               {
+                       return false;
+               }
+       }
 }

--- a/VsHelix/Keymap.cs
+++ b/VsHelix/Keymap.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Text.Utilities;
+using Microsoft.VisualStudio.Text;
+
+namespace VsHelix
+{
+internal sealed class Keymap
+{
+internal delegate bool CommandHandler(char key, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations);
+
+private sealed class Node
+{
+public Dictionary<char, Node> Next { get; } = new();
+public CommandHandler? Command { get; set; }
+}
+
+private readonly Node _root = new();
+private Node? _pending;
+
+public void Add(string keys, CommandHandler handler)
+{
+Node node = _root;
+foreach (char key in keys)
+{
+if (!node.Next.TryGetValue(key, out var child))
+{
+child = new Node();
+node.Next[key] = child;
+}
+node = child;
+}
+node.Command = handler;
+}
+
+public bool TryGetCommand(char key, out CommandHandler? handler)
+{
+handler = null;
+Node node = _pending ?? _root;
+if (!node.Next.TryGetValue(key, out var next))
+{
+_pending = null;
+return false;
+}
+
+if (next.Command != null)
+{
+_pending = null;
+handler = next.Command;
+}
+else
+{
+_pending = next;
+}
+
+return true;
+}
+
+public void Reset()
+{
+_pending = null;
+}
+
+public bool HasPending => _pending != null;
+}
+}

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -30,7 +30,7 @@ namespace VsHelix
                 private SearchMode? _searchMode;
                 public SearchMode? Search => _searchMode;
                 private MatchMode? _matchMode;
-                public MatchMode? Match => _matchMode;
+                internal MatchMode? Match => _matchMode;
 
 
 		private ITextSearchService2 GetSearchService()

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -6,7 +6,6 @@ using System.Text.Json;  // For JSON serialization
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Input;
-using Microsoft.VisualStudio.Extensibility.Editor;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
@@ -27,20 +26,15 @@ namespace VsHelix
 	/// </summary>
 	internal sealed class NormalMode : IInputMode
 	{
-		/// <summary>
-		/// Delegate for handling a Normal mode command.
-		/// </summary>
-		private delegate bool CommandHandler(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations);
-
-                // Map from typed character to its command handler.
-                private readonly Dictionary<char, CommandHandler> _commandMap;
+               // Map from typed character to its command handler.
+                private readonly Keymap _keymap;
 
                 // Stores a pending numeric prefix when the user types digits.
                 private int _pendingCount = 0;
 
 		public NormalMode()
 		{
-			_commandMap = new Dictionary<char, CommandHandler>();
+                        _keymap = new Keymap();
 
 			// ** Movement commands keymap (single-key movements) **
 			var movementCommands = new Dictionary<char, Action<ISelectionTransformer>>
@@ -157,164 +151,166 @@ namespace VsHelix
 			};
 
 			// Register all movement commands to the command map.
-			foreach (var kvp in movementCommands)
-			{
-				_commandMap[kvp.Key] = (args, view, broker, ops) =>
-				{
-					broker.PerformActionOnAllSelections(kvp.Value);
-					return true;
-				};
-			}
+                        foreach (var kvp in movementCommands)
+                        {
+                                _keymap.Add(kvp.Key.ToString(), (c, view, broker, ops) =>
+                                {
+                                        broker.PerformActionOnAllSelections(kvp.Value);
+                                        return true;
+                                });
+                        }
 
 			// ** Other normal-mode commands **
-			_commandMap['i'] = (args, view, broker, ops) =>
-			{
-				// Enter Insert mode at the start of each selection.
-				SelectionManager.Instance.SaveSelections(broker);
-				broker.PerformActionOnAllSelections(sel => MoveCaretToSelectionStart(sel));
-				ModeManager.Instance.EnterInsert(view, broker);
-				return true;
-			};
-			_commandMap['a'] = (args, view, broker, ops) =>
-			{
-				// Enter Insert mode at the end of each selection (append).
-				SelectionManager.Instance.SaveSelections(broker);
-				broker.PerformActionOnAllSelections(sel => MoveCaretToSelectionEnd(sel));
-				ModeManager.Instance.EnterInsert(view, broker);
-				return true;
-			};
-			_commandMap['o'] = (args, view, broker, ops) =>
-			{
-				// Open a new line *below* each selection and enter Insert mode.
-				AddLine(view, broker, ops, above: false);
-				ModeManager.Instance.EnterInsert(view, broker);
-				return true;
-			};
-			_commandMap['O'] = (args, view, broker, ops) =>
-			{
-				// Open a new line *above* each selection and enter Insert mode.
-				AddLine(view, broker, ops, above: true);
-				ModeManager.Instance.EnterInsert(view, broker);
-				return true;
-			};
-                        _commandMap['m'] = (args, view, broker, ops) =>
+                        _keymap.Add("i", (c, view, broker, ops) =>
+                        {
+                                // Enter Insert mode at the start of each selection.
+                                SelectionManager.Instance.SaveSelections(broker);
+                                broker.PerformActionOnAllSelections(sel => MoveCaretToSelectionStart(sel));
+                                ModeManager.Instance.EnterInsert(view, broker);
+                                return true;
+                        });
+                        _keymap.Add("a", (c, view, broker, ops) =>
+                        {
+                                // Enter Insert mode at the end of each selection (append).
+                                SelectionManager.Instance.SaveSelections(broker);
+                                broker.PerformActionOnAllSelections(sel => MoveCaretToSelectionEnd(sel));
+                                ModeManager.Instance.EnterInsert(view, broker);
+                                return true;
+                        });
+                        _keymap.Add("o", (c, view, broker, ops) =>
+                        {
+                                // Open a new line *below* each selection and enter Insert mode.
+                                AddLine(view, broker, ops, above: false);
+                                ModeManager.Instance.EnterInsert(view, broker);
+                                return true;
+                        });
+                        _keymap.Add("O", (c, view, broker, ops) =>
+                        {
+                                // Open a new line *above* each selection and enter Insert mode.
+                                AddLine(view, broker, ops, above: true);
+                                ModeManager.Instance.EnterInsert(view, broker);
+                                return true;
+                        });
+                        _keymap.Add("m", (c, view, broker, ops) =>
                         {
                                 ModeManager.Instance.EnterMatch(view, broker);
                                 return true;
-                        };
-                        _commandMap['/'] = (args, view, broker, ops) =>
-			{
-				SelectionManager.Instance.SaveSelections(broker);
-				var spans = GetSearchDomain(view, broker);
-				ModeManager.Instance.EnterSearch(view, broker, false, spans);
-				return true;
-			};
-			_commandMap['s'] = (args, view, broker, ops) =>
-			{
-				SelectionManager.Instance.SaveSelections(broker);
-				var spans = GetSearchDomain(view, broker);
-				ModeManager.Instance.EnterSearch(view, broker, true, spans);
-				return true;
-			};
-			_commandMap['x'] = (args, view, broker, ops) =>
-			{
-				// Extend selection to full lines, or extend linewise selection to the next line.
-				broker.PerformActionOnAllSelections(sel => ExtendSelectionLinewise(sel, view));
-				return true;
-			};
-			_commandMap['y'] = (args, view, broker, ops) =>
-			{
-				// Yank (copy) current selections.
-				YankSelections(view, broker);
-				return true;
-			};
-			_commandMap['d'] = (args, view, broker, ops) =>
-			{
-				// Delete selection (and yank unless Alt is held).
-				return ExecuteDeleteCommand(view, broker, switchToInsert: false);
-			};
-			_commandMap['c'] = (args, view, broker, ops) =>
-			{
-				// Change (delete then enter Insert mode, and yank unless Alt is held).
-				return ExecuteDeleteCommand(view, broker, switchToInsert: true);
-			};
-			_commandMap['u'] = (args, view, broker, ops) =>
-			{
-				// Undo last edit.
-				var undoManager = view.TextBuffer.Properties.GetProperty<ITextBufferUndoManager>(typeof(ITextBufferUndoManager));
-				var undoHistory = undoManager.TextBufferUndoHistory;
-				if (undoHistory.CanUndo)
-				{
-					undoHistory.Undo(1);
-				}
-				return true;
-			};
-			_commandMap['U'] = (args, view, broker, ops) =>
-			{
-				// Redo last undone edit.
-				var undoManager = view.TextBuffer.Properties.GetProperty<ITextBufferUndoManager>(typeof(ITextBufferUndoManager));
-				var undoHistory = undoManager.TextBufferUndoHistory;
-				if (undoHistory.CanRedo)
-				{
-					undoHistory.Redo(1);
-				}
-				return true;
-			};
-			_commandMap['p'] = (args, view, broker, ops) =>
-			{
-				// Paste from yank register/clipboard.
-				Paste(view, broker);
-				return true;
-			};
-			_commandMap['C'] = (args, view, broker, ops) =>
-			{
-				// Add a new caret below the last selection (multi-cursor).
-				AddCaretBelowLastSelection(view, broker);
-				return true;
-			};
-			_commandMap[','] = (args, view, broker, ops) =>
-			{
-				// Clear all secondary selections, keeping only the primary.
-				broker.ClearSecondarySelections();
-				return true;
-			};
+                        });
+                        _keymap.Add("/", (c, view, broker, ops) =>
+                        {
+                                SelectionManager.Instance.SaveSelections(broker);
+                                var spans = GetSearchDomain(view, broker);
+                                ModeManager.Instance.EnterSearch(view, broker, false, spans);
+                                return true;
+                        });
+                        _keymap.Add("s", (c, view, broker, ops) =>
+                        {
+                                SelectionManager.Instance.SaveSelections(broker);
+                                var spans = GetSearchDomain(view, broker);
+                                ModeManager.Instance.EnterSearch(view, broker, true, spans);
+                                return true;
+                        });
+                        _keymap.Add("x", (c, view, broker, ops) =>
+                        {
+                                // Extend selection to full lines, or extend linewise selection to the next line.
+                                broker.PerformActionOnAllSelections(sel => ExtendSelectionLinewise(sel, view));
+                                return true;
+                        });
+                        _keymap.Add("y", (c, view, broker, ops) =>
+                        {
+                                // Yank (copy) current selections.
+                                YankSelections(view, broker);
+                                return true;
+                        });
+                        _keymap.Add("d", (c, view, broker, ops) =>
+                        {
+                                // Delete selection (and yank unless Alt is held).
+                                return ExecuteDeleteCommand(view, broker, switchToInsert: false);
+                        });
+                        _keymap.Add("c", (c, view, broker, ops) =>
+                        {
+                                // Change (delete then enter Insert mode, and yank unless Alt is held).
+                                return ExecuteDeleteCommand(view, broker, switchToInsert: true);
+                        });
+                        _keymap.Add("u", (c, view, broker, ops) =>
+                        {
+                                // Undo last edit.
+                                var undoManager = view.TextBuffer.Properties.GetProperty<ITextBufferUndoManager>(typeof(ITextBufferUndoManager));
+                                var undoHistory = undoManager.TextBufferUndoHistory;
+                                if (undoHistory.CanUndo)
+                                {
+                                        undoHistory.Undo(1);
+                                }
+                                return true;
+                        });
+                        _keymap.Add("U", (c, view, broker, ops) =>
+                        {
+                                // Redo last undone edit.
+                                var undoManager = view.TextBuffer.Properties.GetProperty<ITextBufferUndoManager>(typeof(ITextBufferUndoManager));
+                                var undoHistory = undoManager.TextBufferUndoHistory;
+                                if (undoHistory.CanRedo)
+                                {
+                                        undoHistory.Redo(1);
+                                }
+                                return true;
+                        });
+                        _keymap.Add("p", (c, view, broker, ops) =>
+                        {
+                                // Paste from yank register/clipboard.
+                                Paste(view, broker);
+                                return true;
+                        });
+                        _keymap.Add("C", (c, view, broker, ops) =>
+                        {
+                                // Add a new caret below the last selection (multi-cursor).
+                                AddCaretBelowLastSelection(view, broker);
+                                return true;
+                        });
+                        _keymap.Add(",", (c, view, broker, ops) =>
+                        {
+                                // Clear all secondary selections, keeping only the primary.
+                                broker.ClearSecondarySelections();
+                                return true;
+                        });
 		}
 
 		/// <summary>
 		/// Handles a typed character command in Normal mode by dispatching to the appropriate action.
 		/// </summary>
-		public bool Handle(TypeCharCommandArgs args, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
-		{
-			char c = args.TypedChar;
-			
-			if (char.IsDigit(c))
-			{
-				int digit = c - '0';
-				_pendingCount = (_pendingCount * 10) + digit;
-				return true;
-			}
-			
-			if (_commandMap.TryGetValue(c, out var handler))
-			{
-				int count = _pendingCount > 0 ? _pendingCount : 1;
-				_pendingCount = 0;
-			
-				bool result = true;
-				for (int i = 0; i < count; i++)
-				{
-					if (ModeManager.Instance.Current != ModeManager.EditorMode.Normal)
-					break;
-			
-					result &= handler(args, view, broker, operations);
-				}
-			
-				return result;
-			}
-			
-				_pendingCount = 0;
-				// Unrecognized key in Normal mode: do nothing (but consume the input to prevent insertion).
-				return true;
-			}
+               public bool HandleChar(char c, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+               {
+                       if (char.IsDigit(c) && !_keymap.HasPending)
+                        {
+                                int digit = c - '0';
+                                _pendingCount = (_pendingCount * 10) + digit;
+                                return true;
+                        }
+
+                        if (_keymap.TryGetCommand(c, out var handler))
+                        {
+                                if (handler != null)
+                                {
+                                        int count = _pendingCount > 0 ? _pendingCount : 1;
+                                        _pendingCount = 0;
+
+                                        bool result = true;
+                                        for (int i = 0; i < count; i++)
+                                        {
+                                                if (ModeManager.Instance.Current != ModeManager.EditorMode.Normal)
+                                                        break;
+
+                                       result &= handler(c, view, broker, operations);
+                                        }
+                                        return result;
+                                }
+                                return true; // awaiting more keys
+                        }
+
+                        _pendingCount = 0;
+                        _keymap.Reset();
+                        // Unrecognized key in Normal mode: consume without inserting.
+                        return true;
+                }
 
 		/// <summary>
 		/// Executes a delete/change command: yanks selections (unless Alt is pressed), deletes them, and optionally enters Insert mode.

--- a/VsHelix/TypeCharFilter.cs
+++ b/VsHelix/TypeCharFilter.cs
@@ -44,21 +44,21 @@ namespace VsHelix
 			var broker = view.GetMultiSelectionBroker();
 			var ops = _editorOperationsFactory.GetEditorOperations(view);
 
-			if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
-			{
-				return _normalMode.Handle(args, view, broker, ops);
-			}
-			else if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
-			{
-				return _insertMode.Handle(args, view, broker, ops);
-			}
+                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
+                        {
+                                return _normalMode.HandleChar(args.TypedChar, view, broker, ops);
+                        }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
+                        {
+                                return _insertMode.HandleChar(args.TypedChar, view, broker, ops);
+                        }
                         else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
                         {
-                                return ModeManager.Instance.Search.Handle(args, view, broker, ops);
+                                return ModeManager.Instance.Search.HandleChar(args.TypedChar, view, broker, ops);
                         }
                         else if (ModeManager.Instance.Current == ModeManager.EditorMode.Match && ModeManager.Instance.Match != null)
                         {
-                                return ModeManager.Instance.Match.Handle(args, view, broker, ops);
+                                return ModeManager.Instance.Match.HandleChar(args.TypedChar, view, broker, ops);
                         }
 
 			return false;


### PR DESCRIPTION
## Summary
- use tabs in `Keymap.cs`
- move SearchMode and MatchMode command dispatch through the keymap
- expose MatchMode via ModeManager internally
- route enter/backspace through mode keymaps for consistency

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877c0c1c838832490d36e8a07181fda