### PR TITLE
Implement Visual mode and shared utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ Press `m` followed by another key to manipulate matching pairs:
 `mm` jumps to the matching bracket, `ms<char>` surrounds the selection,
 `mr<from><to>` replaces the surrounding characters, `md<char>` removes the
 surrounding pair, and `ma`/`mi <char>` select around or inside a pair.
+Press `v` toggles Visual mode where movements extend the current selections.
+While in Visual mode, `y`, `d`, and `c` operate on the selection and return to Normal mode.

--- a/VsHelix/BackspaceKeyHandler.cs
+++ b/VsHelix/BackspaceKeyHandler.cs
@@ -36,7 +36,8 @@ namespace VsHelix
 
                         if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
                                 return ModeManager.Instance.Search.HandleChar('\b', view, broker, ops);
-                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal)
+                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Normal ||
+                            ModeManager.Instance.Current == ModeManager.EditorMode.Visual)
                                 return true; // swallow
 
                         return false;

--- a/VsHelix/EnterKeyHandler.cs
+++ b/VsHelix/EnterKeyHandler.cs
@@ -37,6 +37,8 @@ namespace VsHelix
 
                         if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
                                 return ModeManager.Instance.Search.HandleChar('\r', view, broker, ops);
+                        if (ModeManager.Instance.Current == ModeManager.EditorMode.Visual)
+                                return true;
 
                         return false;
                 }

--- a/VsHelix/EscapeKeyHandler.cs
+++ b/VsHelix/EscapeKeyHandler.cs
@@ -60,6 +60,14 @@ namespace VsHelix
                                 ModeManager.Instance.EnterNormal(view, broker);
                                 return true;
                         }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Visual)
+                        {
+                                var view = args.TextView;
+                                var broker = view.GetMultiSelectionBroker();
+                                ModeManager.Instance.EnterNormal(view, broker);
+                                VisualMode.Instance?.Reset();
+                                return true;
+                        }
 
 
 // In normal mode, also cancel 'esc' keys as that would clear multiple selections.

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -24,7 +24,7 @@ namespace VsHelix
 		public static ModeManager Instance => lazyInstance.Value;
 
 		// --- Your existing class members ---
-		public enum EditorMode { Normal, Insert, Search }
+               public enum EditorMode { Normal, Insert, Visual, Search }
 		public EditorMode Current { get; private set; } = EditorMode.Normal;
 
 		private SearchMode? _searchMode;
@@ -38,12 +38,19 @@ namespace VsHelix
 			return componentModel.GetService<ITextSearchService2>();
 		}
 
-		public void EnterInsert(ITextView view, IMultiSelectionBroker broker)
-		{
-			Current = EditorMode.Insert;
-			StatusBarHelper.ShowMode(Current);
-			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, false);
-		}
+                public void EnterInsert(ITextView view, IMultiSelectionBroker broker)
+                {
+                        Current = EditorMode.Insert;
+                        StatusBarHelper.ShowMode(Current);
+                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, false);
+                }
+
+               public void EnterVisual(ITextView view, IMultiSelectionBroker broker)
+               {
+                       Current = EditorMode.Visual;
+                       StatusBarHelper.ShowMode(Current);
+                       view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
+               }
 
 		public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
 		{

--- a/VsHelix/SelectionUtils.cs
+++ b/VsHelix/SelectionUtils.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Windows;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
+using Microsoft.VisualStudio.Text.Formatting;
+using Microsoft.VisualStudio.Text.Operations;
+
+namespace VsHelix
+{
+internal static class SelectionUtils
+{
+internal static int CalculateExpandedOffset(string text, int tabSize)
+{
+int expandedLength = 0;
+foreach (char c in text)
+{
+if (c == '\t')
+{
+int spacesForTab = tabSize - (expandedLength % tabSize);
+expandedLength += spacesForTab;
+}
+else
+{
+expandedLength++;
+}
+}
+return expandedLength;
+}
+
+internal static VirtualSnapshotPoint CreatePointAtVisualOffset(ITextSnapshotLine line, int visualOffset, int tabSize)
+{
+string lineText = line.GetText();
+int currentVisualOffset = 0;
+int charOffset = 0;
+
+while (charOffset < lineText.Length && currentVisualOffset < visualOffset)
+{
+if (lineText[charOffset] == '\t')
+{
+int spacesForTab = tabSize - (currentVisualOffset % tabSize);
+currentVisualOffset += spacesForTab;
+}
+else
+{
+currentVisualOffset++;
+}
+
+if (currentVisualOffset <= visualOffset)
+{
+charOffset++;
+}
+}
+
+int virtualSpaces = visualOffset - currentVisualOffset;
+if (virtualSpaces < 0) virtualSpaces = 0;
+
+var basePoint = new SnapshotPoint(line.Snapshot, line.Start.Position + charOffset);
+return new VirtualSnapshotPoint(basePoint, virtualSpaces);
+}
+
+internal static void ExtendSelectionLinewise(ISelectionTransformer transformer, ITextView view)
+{
+var snapshot = view.TextSnapshot;
+var currentSelection = transformer.Selection;
+var startLine = currentSelection.Start.Position.GetContainingLine();
+var endLine = currentSelection.End.Position.GetContainingLine();
+
+bool isAlreadyLinewise = currentSelection.Start.Position == startLine.Start &&
+  currentSelection.End.Position == endLine.End;
+
+VirtualSnapshotPoint newStart, newEnd;
+if (!isAlreadyLinewise)
+{
+newStart = new VirtualSnapshotPoint(startLine.Start);
+newEnd = new VirtualSnapshotPoint(endLine.End);
+}
+else
+{
+if (endLine.LineNumber + 1 < snapshot.LineCount)
+{
+var nextLine = snapshot.GetLineFromLineNumber(endLine.LineNumber + 1);
+newStart = new VirtualSnapshotPoint(startLine.Start);
+newEnd = new VirtualSnapshotPoint(nextLine.End);
+}
+else
+{
+newStart = new VirtualSnapshotPoint(startLine.Start);
+newEnd = new VirtualSnapshotPoint(endLine.End);
+}
+}
+
+var newSpan = new VirtualSnapshotSpan(newStart, newEnd);
+transformer.MoveTo(newSpan.Start, false, PositionAffinity.Successor);
+transformer.MoveTo(newSpan.End, true, PositionAffinity.Successor);
+}
+
+internal static bool IsLinewiseSelection(Selection sel, ITextSnapshot snapshot)
+{
+if (sel.IsEmpty || sel.Start.IsInVirtualSpace || sel.End.IsInVirtualSpace)
+return false;
+
+var startLine = sel.Start.Position.GetContainingLine();
+var endLine = sel.End.Position.GetContainingLine();
+return sel.Start.Position == startLine.Start && sel.End.Position == endLine.End;
+}
+
+internal static void DeleteSelections(ITextView view, IMultiSelectionBroker broker)
+{
+var selections = broker.AllSelections.ToList();
+if (!selections.Any())
+return;
+
+using (var edit = view.TextBuffer.CreateEdit())
+{
+foreach (var sel in selections.OrderByDescending(s => s.Start.Position))
+{
+if (sel.IsEmpty) continue;
+
+var spanToDelete = new SnapshotSpan(sel.Start.Position, sel.End.Position);
+if (IsLinewiseSelection(sel, view.TextSnapshot))
+{
+var endLine = sel.End.Position.GetContainingLine();
+if (endLine.End.Position < endLine.EndIncludingLineBreak.Position)
+{
+spanToDelete = new SnapshotSpan(sel.Start.Position, endLine.EndIncludingLineBreak);
+}
+}
+edit.Delete(spanToDelete);
+}
+edit.Apply();
+}
+
+broker.PerformActionOnAllSelections(transformer =>
+{
+var start = transformer.Selection.Start;
+transformer.MoveTo(start, false, PositionAffinity.Successor);
+});
+}
+
+internal static void YankSelections(ITextView view, IMultiSelectionBroker broker)
+{
+var snapshot = view.TextSnapshot;
+var selections = broker.AllSelections.ToList();
+if (selections.Count == 0)
+return;
+
+var yankRegister = new List<YankItem>();
+var concatenatedText = new StringBuilder();
+
+foreach (var sel in selections)
+{
+var span = new SnapshotSpan(sel.Start.Position, sel.End.Position);
+string text = span.GetText();
+bool isLinewise = IsLinewiseSelection(sel, snapshot);
+
+if (isLinewise)
+{
+text += Environment.NewLine;
+}
+
+yankRegister.Add(new YankItem(text, isLinewise));
+concatenatedText.Append(text);
+}
+
+string clipboardText = concatenatedText.ToString();
+if (yankRegister.Any(item => item.IsLinewise) && !clipboardText.EndsWith(Environment.NewLine))
+{
+clipboardText += Environment.NewLine;
+}
+
+var dataObject = new DataObject();
+dataObject.SetText(clipboardText);
+string json = JsonSerializer.Serialize(yankRegister);
+dataObject.SetData("MyVsHelixYankFormat", json);
+
+try
+{
+Clipboard.SetDataObject(dataObject, true);
+}
+catch
+{
+}
+}
+}
+}

--- a/VsHelix/StatusBarHelper.cs
+++ b/VsHelix/StatusBarHelper.cs
@@ -11,9 +11,10 @@ namespace VsHelix
 			var status = ServiceProvider.GlobalProvider.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
 			var text = mode switch
 			{
-				ModeManager.EditorMode.Normal => "NOR",
-				ModeManager.EditorMode.Insert => "INS",
-                                ModeManager.EditorMode.Search => "SCH",
+                               ModeManager.EditorMode.Normal => "NOR",
+                               ModeManager.EditorMode.Insert => "INS",
+                               ModeManager.EditorMode.Visual => "VIS",
+                               ModeManager.EditorMode.Search => "SCH",
                                 _ => mode.ToString().ToUpperInvariant(),
 			};
 			if (!string.IsNullOrEmpty(extra))

--- a/VsHelix/TypeCharFilter.cs
+++ b/VsHelix/TypeCharFilter.cs
@@ -24,8 +24,9 @@ namespace VsHelix
 		private const string ModeKey = nameof(TypeCharFilter) + "_mode";
 
 		private readonly IEditorOperationsFactoryService _editorOperationsFactory;
-		private readonly IInputMode _insertMode = new InsertMode();
-		private readonly IInputMode _normalMode = new NormalMode();
+                private readonly IInputMode _insertMode = new InsertMode();
+                private readonly IInputMode _normalMode = new NormalMode();
+                private readonly IInputMode _visualMode = new VisualMode();
 
 		[ImportingConstructor]
 		internal TypeCharFilter(IEditorOperationsFactoryService editorOperationsFactory)
@@ -51,6 +52,10 @@ namespace VsHelix
                         else if (ModeManager.Instance.Current == ModeManager.EditorMode.Insert)
                         {
                                 return _insertMode.HandleChar(args.TypedChar, view, broker, ops);
+                        }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Visual)
+                        {
+                                return _visualMode.HandleChar(args.TypedChar, view, broker, ops);
                         }
                         else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
                         {

--- a/VsHelix/VisualMode.cs
+++ b/VsHelix/VisualMode.cs
@@ -1,0 +1,180 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Text.Operations;
+
+namespace VsHelix
+{
+internal sealed class VisualMode : IInputMode
+{
+internal static VisualMode? Instance { get; private set; }
+
+private readonly Keymap _keymap;
+private int _pendingCount = 0;
+
+public VisualMode()
+{
+Instance = this;
+_keymap = new Keymap();
+
+var movementCommands = new Dictionary<char, System.Action<ITextView, ISelectionTransformer>>
+{
+['h'] = (view, sel) =>
+{
+var active = sel.Selection.ActivePoint;
+var line = active.Position.GetContainingLine();
+if (active.Position > line.Start)
+{
+var prev = active.Position - 1;
+sel.MoveTo(new VirtualSnapshotPoint(view.TextSnapshot, prev), true, PositionAffinity.Predecessor);
+}
+},
+['l'] = (view, sel) =>
+{
+var active = sel.Selection.ActivePoint;
+var line = active.Position.GetContainingLine();
+if (active.Position < line.End)
+{
+var next = active.Position + 1;
+sel.MoveTo(new VirtualSnapshotPoint(view.TextSnapshot, next), true, PositionAffinity.Successor);
+}
+},
+['j'] = (view, sel) =>
+{
+var active = sel.Selection.ActivePoint;
+var line = active.Position.GetContainingLine();
+var snapshot = view.TextSnapshot;
+if (line.LineNumber + 1 < snapshot.LineCount)
+{
+var nextLine = snapshot.GetLineFromLineNumber(line.LineNumber + 1);
+int tabSize = view.Options.GetTabSize();
+int posInLine = active.Position - line.Start.Position;
+string textToPos = line.GetText().Substring(0, posInLine);
+int expanded = SelectionUtils.CalculateExpandedOffset(textToPos, tabSize);
+expanded += active.VirtualSpaces;
+var target = SelectionUtils.CreatePointAtVisualOffset(nextLine, expanded, tabSize);
+sel.MoveTo(target, true);
+}
+},
+['k'] = (view, sel) =>
+{
+var active = sel.Selection.ActivePoint;
+var line = active.Position.GetContainingLine();
+var snapshot = view.TextSnapshot;
+if (line.LineNumber > 0)
+{
+var prevLine = snapshot.GetLineFromLineNumber(line.LineNumber - 1);
+int tabSize = view.Options.GetTabSize();
+int posInLine = active.Position - line.Start.Position;
+string textToPos = line.GetText().Substring(0, posInLine);
+int expanded = SelectionUtils.CalculateExpandedOffset(textToPos, tabSize);
+expanded += active.VirtualSpaces;
+var target = SelectionUtils.CreatePointAtVisualOffset(prevLine, expanded, tabSize);
+sel.MoveTo(target, true);
+}
+},
+['w'] = (view, sel) => sel.PerformAction(PredefinedSelectionTransformations.SelectToNextSubWord),
+['W'] = (view, sel) => sel.PerformAction(PredefinedSelectionTransformations.SelectToNextWord),
+['b'] = (view, sel) => sel.PerformAction(PredefinedSelectionTransformations.SelectToPreviousSubWord),
+['B'] = (view, sel) => sel.PerformAction(PredefinedSelectionTransformations.SelectToPreviousWord)
+};
+
+foreach (var kvp in movementCommands)
+{
+_keymap.Add(kvp.Key.ToString(), (c, view, broker, ops) =>
+{
+broker.PerformActionOnAllSelections(sel => kvp.Value(view, sel));
+return true;
+});
+}
+
+_keymap.Add("y", (c, view, broker, ops) =>
+{
+SelectionUtils.YankSelections(view, broker);
+ModeManager.Instance.EnterNormal(view, broker);
+return true;
+});
+_keymap.Add("d", (c, view, broker, ops) =>
+{
+ExecuteDeleteCommand(view, broker, false);
+ModeManager.Instance.EnterNormal(view, broker);
+return true;
+});
+_keymap.Add("c", (c, view, broker, ops) =>
+{
+ExecuteDeleteCommand(view, broker, true);
+return true;
+});
+
+_keymap.Add("x", (c, view, broker, ops) =>
+{
+broker.PerformActionOnAllSelections(sel => SelectionUtils.ExtendSelectionLinewise(sel, view));
+return true;
+});
+
+_keymap.Add("v", (c, view, broker, ops) =>
+{
+ModeManager.Instance.EnterNormal(view, broker);
+return true;
+});
+}
+
+public bool HandleChar(char c, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+{
+if (char.IsDigit(c) && !_keymap.HasPending)
+{
+int digit = c - '0';
+_pendingCount = (_pendingCount * 10) + digit;
+return true;
+}
+
+if (_keymap.TryGetCommand(c, out var handler))
+{
+if (handler != null)
+{
+int count = _pendingCount > 0 ? _pendingCount : 1;
+_pendingCount = 0;
+
+bool result = true;
+for (int i = 0; i < count; i++)
+{
+if (ModeManager.Instance.Current != ModeManager.EditorMode.Visual)
+break;
+
+result &= handler(c, view, broker, operations);
+}
+return result;
+}
+return true;
+}
+
+_pendingCount = 0;
+_keymap.Reset();
+return true;
+}
+
+private bool ExecuteDeleteCommand(ITextView view, IMultiSelectionBroker broker, bool switchToInsert)
+{
+bool altDown = (System.Windows.Input.Keyboard.Modifiers & System.Windows.Input.ModifierKeys.Alt) != 0;
+if (!altDown)
+{
+SelectionUtils.YankSelections(view, broker);
+}
+
+SelectionUtils.DeleteSelections(view, broker);
+
+if (switchToInsert)
+{
+ModeManager.Instance.EnterInsert(view, broker);
+}
+return true;
+}
+
+internal void Reset()
+{
+_keymap.Reset();
+_pendingCount = 0;
+}
+}
+}

--- a/VsHelix/YankItem.cs
+++ b/VsHelix/YankItem.cs
@@ -1,0 +1,7 @@
+namespace VsHelix
+{
+/// <summary>
+/// Record type for yanked items used for clipboard serialization.
+/// </summary>
+internal record YankItem(string Text, bool IsLinewise);
+}


### PR DESCRIPTION
## Summary
- add VisualMode with basic motions and operators
- factor repeated selection logic into `SelectionUtils`
- support Visual state in mode manager, handlers, and status bar
- document Visual mode usage

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_68788618d88c8324b34a541647a99f15