### PR TITLE
Helix style visual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Press `m` followed by another key to manipulate matching pairs:
 `mr<from><to>` replaces the surrounding characters, `md<char>` removes the
 surrounding pair, and `ma`/`mi <char>` select around or inside a pair.
 Press `v` toggles Visual mode where movements extend the current selections.
-While in Visual mode, `y`, `d`, and `c` operate on the selection and return to Normal mode.
+While in Visual mode, motions grow the selection with a fixed anchor. Use `y`, `d`, `c`, or `p` to yank, delete, change, or replace the selections. `C` and `K` duplicate the selections down or up to form multi-line blocks. Hitting <kbd>Esc</kbd> leaves Visual mode but keeps the selection active in Normal mode.

--- a/VsHelix/SelectionManager.cs
+++ b/VsHelix/SelectionManager.cs
@@ -14,12 +14,12 @@ namespace VsHelix
 		public ITrackingPoint ActivePoint { get; }
 		public bool IsReversed { get; }
 
-		public TrackedSelection(Selection selection, ITextSnapshot snapshot)
-		{
-			AnchorPoint = snapshot.CreateTrackingPoint(selection.Start.Position, PointTrackingMode.Positive);
-			ActivePoint = snapshot.CreateTrackingPoint(selection.End.Position, PointTrackingMode.Positive);
-			//IsReversed = selection.IsReversed;
-		}
+               public TrackedSelection(Selection selection, ITextSnapshot snapshot)
+               {
+                       AnchorPoint = snapshot.CreateTrackingPoint(selection.Start.Position, PointTrackingMode.Positive);
+                       ActivePoint = snapshot.CreateTrackingPoint(selection.End.Position, PointTrackingMode.Positive);
+                       IsReversed = selection.IsReversed;
+               }
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary
- update VisualMode to extend selections like Helix
- support paste-over selections and vertical block cursor duplication
- allow creating cursors above the first selection
- track selection direction when saving/restoring
- document new visual-mode commands

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_687970862040832485a7edcfd2f8f6f3