### PR TITLE
Add Goto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,13 @@ Press `m` followed by another key to manipulate matching pairs:
 surrounding pair, and `ma`/`mi <char>` select around or inside a pair.
 Press `v` toggles Visual mode where movements extend the current selections.
 While in Visual mode, motions grow the selection with a fixed anchor. Use `y`, `d`, `c`, or `p` to yank, delete, change, or replace the selections. `C` and `K` duplicate the selections down or up to form multi-line blocks. Hitting <kbd>Esc</kbd> leaves Visual mode but keeps the selection active in Normal mode.
+
+Press `g` to enter **Goto** mode. The status bar shows `GTO` while waiting for a second key.
+`gg` jumps to a specified line number (or the start of the file), `ge` goes to the end
+of the file and `gf` opens files whose paths are under the selections. Use `gh`, `gl`
+and `gs` for the start, end, and first non-whitespace of the line. `gt`, `gc` and
+`gb` move the caret to the top, middle or bottom of the visible editor. The keys
+`gd`, `gy`, `gr` and `gi` trigger Visual Studio's Go To Definition, Type Definition,
+References and Implementation commands. `ga`/`gm` navigate backward or forward in
+file history, `gn`/`gp` switch between documents and `g.` returns to the last edit
+location. `gj` and `gk` move by textual lines.

--- a/VsHelix/EscapeKeyHandler.cs
+++ b/VsHelix/EscapeKeyHandler.cs
@@ -68,6 +68,13 @@ namespace VsHelix
                                 VisualMode.Instance?.Reset();
                                 return true;
                         }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Goto)
+                        {
+                                var view = args.TextView;
+                                var broker = view.GetMultiSelectionBroker();
+                                ModeManager.Instance.EnterNormal(view, broker);
+                                return true;
+                        }
 
 
 // In normal mode, also cancel 'esc' keys as that would clear multiple selections.

--- a/VsHelix/GotoMode.cs
+++ b/VsHelix/GotoMode.cs
@@ -1,0 +1,181 @@
+using System;
+using System.IO;
+using System.Linq;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Text.Formatting;
+
+namespace VsHelix
+{
+internal sealed class GotoMode : IInputMode
+{
+private readonly Keymap _keymap;
+private int _pendingNumber;
+
+internal GotoMode()
+{
+_keymap = new Keymap();
+
+_keymap.Add("g", (c, v, b, o) => { GoToLine(v, b); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("e", (c, v, b, o) => { GoToEndOfFile(v, b); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("f", (c, v, b, o) => { GoToFile(v, b); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("h", (c, v, b, o) => { GoToLineStart(v, b); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("l", (c, v, b, o) => { GoToLineEnd(v, b); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("s", (c, v, b, o) => { GoToFirstNonWhitespace(v, b); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("t", (c, v, b, o) => { GoToTop(v); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("c", (c, v, b, o) => { GoToMiddle(v); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("b", (c, v, b, o) => { GoToBottom(v); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("d", (c, v, b, o) => { ExecuteCommand("Edit.GoToDefinition"); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("y", (c, v, b, o) => { ExecuteCommand("Edit.GoToTypeDefinition"); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("r", (c, v, b, o) => { ExecuteCommand("Edit.GoToAllReferences"); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("i", (c, v, b, o) => { ExecuteCommand("Edit.GoToImplementation"); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("a", (c, v, b, o) => { ExecuteCommand("View.NavigateBackward"); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("m", (c, v, b, o) => { ExecuteCommand("View.NavigateForward"); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("n", (c, v, b, o) => { ExecuteCommand("Window.NextDocumentWindow"); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("p", (c, v, b, o) => { ExecuteCommand("Window.PreviousDocumentWindow"); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add(".", (c, v, b, o) => { ExecuteCommand("Edit.GoToLastEditLocation"); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("j", (c, v, b, o) => { MoveDown(b); ModeManager.Instance.EnterNormal(v, b); return true; });
+_keymap.Add("k", (c, v, b, o) => { MoveUp(b); ModeManager.Instance.EnterNormal(v, b); return true; });
+}
+
+public bool HandleChar(char ch, ITextView view, IMultiSelectionBroker broker, IEditorOperations operations)
+{
+if (ch == '\b')
+{
+_pendingNumber /= 10;
+StatusBarHelper.ShowMode(ModeManager.EditorMode.Goto, _pendingNumber > 0 ? _pendingNumber.ToString() : string.Empty);
+return true;
+}
+
+if (char.IsDigit(ch) && !_keymap.HasPending)
+{
+_pendingNumber = (_pendingNumber * 10) + (ch - '0');
+StatusBarHelper.ShowMode(ModeManager.EditorMode.Goto, _pendingNumber.ToString());
+return true;
+}
+
+if (_keymap.TryGetCommand(ch, out var handler))
+{
+if (handler != null)
+{
+var result = handler(ch, view, broker, operations);
+_pendingNumber = 0;
+_keymap.Reset();
+return result;
+}
+return true;
+}
+
+_pendingNumber = 0;
+_keymap.Reset();
+ModeManager.Instance.EnterNormal(view, broker);
+return true;
+}
+
+private void GoToLine(ITextView view, IMultiSelectionBroker broker)
+{
+var snapshot = view.TextSnapshot;
+int lineNum = _pendingNumber > 0 ? _pendingNumber - 1 : 0;
+_pendingNumber = 0;
+if (lineNum < 0) lineNum = 0;
+if (lineNum >= snapshot.LineCount) lineNum = snapshot.LineCount - 1;
+var line = snapshot.GetLineFromLineNumber(lineNum);
+broker.PerformActionOnAllSelections(sel => sel.MoveTo(new VirtualSnapshotPoint(line.Start), false, PositionAffinity.Successor));
+view.Caret.EnsureVisible();
+}
+
+private void GoToEndOfFile(ITextView view, IMultiSelectionBroker broker)
+{
+var snapshot = view.TextSnapshot;
+var point = new SnapshotPoint(snapshot, snapshot.Length);
+broker.PerformActionOnAllSelections(sel => sel.MoveTo(new VirtualSnapshotPoint(point), false, PositionAffinity.Predecessor));
+view.Caret.EnsureVisible();
+}
+
+private void GoToFile(ITextView view, IMultiSelectionBroker broker)
+{
+foreach (var sel in broker.AllSelections)
+{
+var span = new SnapshotSpan(sel.Start.Position, sel.End.Position);
+string text = span.GetText();
+if (File.Exists(text))
+{
+VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, text);
+}
+}
+}
+
+private void GoToLineStart(ITextView view, IMultiSelectionBroker broker)
+{
+broker.PerformActionOnAllSelections(sel =>
+{
+var line = sel.Selection.ActivePoint.Position.GetContainingLine();
+sel.MoveTo(new VirtualSnapshotPoint(line.Start), false, PositionAffinity.Successor);
+});
+}
+
+private void GoToLineEnd(ITextView view, IMultiSelectionBroker broker)
+{
+broker.PerformActionOnAllSelections(sel =>
+{
+var line = sel.Selection.ActivePoint.Position.GetContainingLine();
+sel.MoveTo(new VirtualSnapshotPoint(line.End), false, PositionAffinity.Predecessor);
+});
+}
+
+private void GoToFirstNonWhitespace(ITextView view, IMultiSelectionBroker broker)
+{
+broker.PerformActionOnAllSelections(sel =>
+{
+var line = sel.Selection.ActivePoint.Position.GetContainingLine();
+string text = line.GetText();
+int offset = 0;
+while (offset < text.Length && char.IsWhiteSpace(text[offset])) offset++;
+sel.MoveTo(new VirtualSnapshotPoint(new SnapshotPoint(line.Snapshot, line.Start.Position + offset)), false, PositionAffinity.Successor);
+});
+}
+
+private void GoToTop(ITextView view)
+{
+var first = view.TextViewLines.FirstVisibleLine;
+view.Caret.MoveTo(first.Start);
+view.Caret.EnsureVisible();
+}
+
+private void GoToMiddle(ITextView view)
+{
+var lines = view.TextViewLines;
+int idx = lines.Count / 2;
+var line = lines[idx];
+view.Caret.MoveTo(line.Start);
+view.Caret.EnsureVisible();
+}
+
+private void GoToBottom(ITextView view)
+{
+var last = view.TextViewLines.LastVisibleLine;
+view.Caret.MoveTo(last.Start);
+view.Caret.EnsureVisible();
+}
+
+private static void ExecuteCommand(string command)
+{
+ThreadHelper.ThrowIfNotOnUIThread();
+var dte = ServiceProvider.GlobalProvider.GetService(typeof(DTE)) as DTE;
+dte?.ExecuteCommand(command);
+}
+
+private static void MoveDown(IMultiSelectionBroker broker)
+{
+broker.PerformActionOnAllSelections(sel => sel.PerformAction(PredefinedSelectionTransformations.MoveToNextLine));
+}
+
+private static void MoveUp(IMultiSelectionBroker broker)
+{
+broker.PerformActionOnAllSelections(sel => sel.PerformAction(PredefinedSelectionTransformations.MoveToPreviousLine));
+}
+}
+}

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -24,7 +24,7 @@ namespace VsHelix
 		public static ModeManager Instance => lazyInstance.Value;
 
 		// --- Your existing class members ---
-               public enum EditorMode { Normal, Insert, Visual, Search }
+               public enum EditorMode { Normal, Insert, Visual, Search, Goto }
 		public EditorMode Current { get; private set; } = EditorMode.Normal;
 
 		private SearchMode? _searchMode;
@@ -52,13 +52,20 @@ namespace VsHelix
                        view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
                }
 
-		public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
-		{
-			Current = EditorMode.Search;
-			_searchMode = new SearchMode(selectAll, view, broker, domain, GetSearchService());
-			StatusBarHelper.ShowMode(Current);
-			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
-		}
+               public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
+               {
+                       Current = EditorMode.Search;
+                       _searchMode = new SearchMode(selectAll, view, broker, domain, GetSearchService());
+                       StatusBarHelper.ShowMode(Current);
+                       view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
+               }
+
+               public void EnterGoto(ITextView view, IMultiSelectionBroker broker)
+               {
+                       Current = EditorMode.Goto;
+                       StatusBarHelper.ShowMode(Current);
+                       view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
+               }
 
 		public void EnterNormal(ITextView view, IMultiSelectionBroker broker)
 		{

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -220,14 +220,19 @@ namespace VsHelix
 				ModeManager.Instance.EnterInsert(view, broker);
 				return true;
 			});
-			_keymap.Add("O", (c, view, broker, ops) =>
-			{
-				// Open a new line *above* each selection and enter Insert mode.
-				AddLine(view, broker, ops, above: true);
-				ModeManager.Instance.EnterInsert(view, broker);
-				return true;
-			});
-			_keymap.Add("m", null); // prefix for match commands
+                        _keymap.Add("O", (c, view, broker, ops) =>
+                        {
+                                // Open a new line *above* each selection and enter Insert mode.
+                                AddLine(view, broker, ops, above: true);
+                                ModeManager.Instance.EnterInsert(view, broker);
+                                return true;
+                        });
+                        _keymap.Add("g", (c, view, broker, ops) =>
+                        {
+                                ModeManager.Instance.EnterGoto(view, broker);
+                                return true;
+                        });
+                        _keymap.Add("m", null); // prefix for match commands
 			_keymap.Add("mm", (c, view, broker, ops) =>
 			{
 				broker.PerformActionOnAllSelections(sel => GoToMatchingBracket(sel));

--- a/VsHelix/StatusBarHelper.cs
+++ b/VsHelix/StatusBarHelper.cs
@@ -15,8 +15,9 @@ namespace VsHelix
                                ModeManager.EditorMode.Insert => "INS",
                                ModeManager.EditorMode.Visual => "VIS",
                                ModeManager.EditorMode.Search => "SCH",
+                               ModeManager.EditorMode.Goto => "GTO",
                                 _ => mode.ToString().ToUpperInvariant(),
-			};
+                        };
 			if (!string.IsNullOrEmpty(extra))
 				status?.SetText($"{text} {extra}");
 			else

--- a/VsHelix/TypeCharFilter.cs
+++ b/VsHelix/TypeCharFilter.cs
@@ -27,6 +27,7 @@ namespace VsHelix
                 private readonly IInputMode _insertMode = new InsertMode();
                 private readonly IInputMode _normalMode = new NormalMode();
                 private readonly IInputMode _visualMode = new VisualMode();
+                private readonly IInputMode _gotoMode = new GotoMode();
 
 		[ImportingConstructor]
 		internal TypeCharFilter(IEditorOperationsFactoryService editorOperationsFactory)
@@ -56,6 +57,10 @@ namespace VsHelix
                         else if (ModeManager.Instance.Current == ModeManager.EditorMode.Visual)
                         {
                                 return _visualMode.HandleChar(args.TypedChar, view, broker, ops);
+                        }
+                        else if (ModeManager.Instance.Current == ModeManager.EditorMode.Goto)
+                        {
+                                return _gotoMode.HandleChar(args.TypedChar, view, broker, ops);
                         }
                         else if (ModeManager.Instance.Current == ModeManager.EditorMode.Search && ModeManager.Instance.Search != null)
                         {


### PR DESCRIPTION
## Summary
- add new GotoMode implementing Helix-style goto commands
- show GTO status in status bar
- support entering goto mode from normal mode
- route characters to goto mode
- document goto mode usage

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ae8ed9dc8324ac3b8210466d1c76