### PR TITLE
Fix navigation forward COM error

### DIFF
--- a/VsHelix/GotoMode.cs
+++ b/VsHelix/GotoMode.cs
@@ -165,7 +165,19 @@ private static void ExecuteCommand(string command)
 {
 ThreadHelper.ThrowIfNotOnUIThread();
 var dte = ServiceProvider.GlobalProvider.GetService(typeof(DTE)) as DTE;
-dte?.ExecuteCommand(command);
+if (dte == null)
+return;
+
+try
+{
+var cmd = dte.Commands.Item(command);
+if (cmd != null && cmd.IsAvailable)
+dte.ExecuteCommand(command);
+}
+catch (Exception)
+{
+// Ignore unavailable commands
+}
 }
 
 private static void MoveDown(IMultiSelectionBroker broker)


### PR DESCRIPTION
## Summary
- ensure commands are available before invoking them

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c8df81d88324b3c8034f306a1bf2