### PR TITLE
Fix escape handler ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ copying.
 Press `u` to undo and `U` to redo the last action.
 Type a number before any normal-mode command to repeat it that many times.
 Pressing <kbd>Esc</kbd> now closes any active IntelliSense sessions before
-returning to normal mode.
+returning to normal mode. The handler executes ahead of Visual Studio's default
+Escape logic so mode transitions always occur reliably.
 Pressing <kbd>,</kbd> clears all secondary selections, leaving a single cursor.
 Use `s` to select all matches of a regex typed inline. `/` performs an incremental search that highlights matches as you type. While searching, `n` and `N` jump to the next or previous match. Press **Enter** to accept the search or **Esc** to cancel. Enter and Backspace are now dispatched through the same keymap as other characters.
 Press `m` followed by another key to manipulate matching pairs:

--- a/VsHelix/EscapeKeyHandler.cs
+++ b/VsHelix/EscapeKeyHandler.cs
@@ -13,7 +13,8 @@ namespace VsHelix
 	[ContentType("text")]
 	[TextViewRole(PredefinedTextViewRoles.Editable)]
 	[Name(nameof(EscapeKeyHandler))]
-	[Order(Before = "TypeChar")]
+	// Run before the default Escape handler so we always regain Normal mode.
+	[Order(Before = "Escape")]
 	[VisualStudioContribution]
 	internal sealed class EscapeKeyHandler : ICommandHandler<EscapeKeyCommandArgs>
 	{


### PR DESCRIPTION
## Summary
- ensure Escape handler runs before Visual Studio's default
- clarify README about reliable Esc handling

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e708d2508324bb79a2c15edd0a67