### PR TITLE
Disable reference highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ command handler and will grow into a small set of core commands.
 5. Press `w` to extend each caret to the start of the next word.
 6. Use `h`, `j`, `k`, and `l` to move all carets left, down, up, or right by one character or line.
 7. Carets display as thin vertical bars in both modes for a consistent insert-style look.
+8. Reference highlighting is disabled in Normal mode so only the actual selection is shown.
 
 The provided `VsHelixPackage` is a standard AsyncPackage.  Command handlers are
 added via MEF exports.  When the project is built in *Release* configuration it

--- a/VsHelix/NormalModeSelectionBehavior.cs
+++ b/VsHelix/NormalModeSelectionBehavior.cs
@@ -16,6 +16,7 @@ namespace VsHelix
 		public void TextViewCreated(IWpfTextView textView)
 		{
 			textView.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);  // block caret
+			textView.Options.SetOptionValue(DefaultTextViewOptions.ReferenceHighlightingId, false);	// disable similar word highlighting
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- disable ReferenceHighlighting option when creating text views so Visual Studio only highlights the actual selection
- document the setting in README

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e5e810488324875a7be59c3cbb1c