### PR TITLE
Add Helix word motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ command handler and will grow into a small set of core commands.
    extension automatically loaded.
 4. Open any text file in the experimental instance.  Use
    `Ctrl+Alt+Click` to place additional carets.
-5. Press `w` to extend each caret to the start of the next word.
+5. Use `w`, `b`, and `e` to move forward, backward, or to the end of a word.
+   Uppercase `W`, `B`, and `E` operate on whitespace-delimited WORDs.
 6. Use `h`, `j`, `k`, and `l` to move all carets left, down, up, or right by one character or line.
 7. Carets display as thin vertical bars in both modes for a consistent insert-style look.
 
@@ -39,7 +40,7 @@ or using `VSIXInstaller.exe`.
 - `source.extension.vsixmanifest` – Extension manifest used by Visual Studio.
 
 The extension includes a `HelixCommandHandler` implementing basic motions like
-`w` for word forward as well as `h`, `j`, `k`, and `l` for left, down, up, and
+`w`, `b`, and `e` for word movement as well as `h`, `j`, `k`, and `l` for left, down, up, and
 right movement across all selections.  The `x` key selects the current line
 including its trailing newline and extends to the next line when pressed
 repeatedly.  Pressing `C`

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -159,26 +159,36 @@ namespace VsHelix
 
 
 				// Word-wise movements (clear selection then extend)
-				['w'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					sel.PerformAction(PredefinedSelectionTransformations.SelectToNextSubWord);
-				},  // Next sub-word
-				['W'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					sel.PerformAction(PredefinedSelectionTransformations.SelectToNextWord);
-				},  // Next Word
-				['b'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					sel.PerformAction(PredefinedSelectionTransformations.SelectToPreviousSubWord);
-				},  // Previous sub-word
-				['B'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					sel.PerformAction(PredefinedSelectionTransformations.SelectToPreviousWord);
-				}   // Previous Word
+                               ['w'] = sel =>
+                               {
+                                       sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
+                                       SelectionUtils.MoveToNextWordStart(sel, false);
+                               },  // Next word
+                               ['W'] = sel =>
+                               {
+                                       sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
+                                       SelectionUtils.MoveToNextLongWordStart(sel, false);
+                               },  // Next WORD
+                               ['b'] = sel =>
+                               {
+                                       sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
+                                       SelectionUtils.MoveToPreviousWordStart(sel, false);
+                               },  // Previous word
+                               ['B'] = sel =>
+                               {
+                                       sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
+                                       SelectionUtils.MoveToPreviousLongWordStart(sel, false);
+                               },  // Previous WORD
+                               ['e'] = sel =>
+                               {
+                                       sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
+                                       SelectionUtils.MoveToNextWordEnd(sel, false);
+                               },  // End of word
+                               ['E'] = sel =>
+                               {
+                                       sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
+                                       SelectionUtils.MoveToNextLongWordEnd(sel, false);
+                               }   // End of WORD
 			};
 
 			// Register all movement commands to the command map.

--- a/VsHelix/SelectionUtils.cs
+++ b/VsHelix/SelectionUtils.cs
@@ -182,9 +182,156 @@ namespace VsHelix
 			{
 				Clipboard.SetDataObject(dataObject, true);
 			}
-			catch
-			{
+catch
+{
+}
+}
+
+private static bool IsWordChar(char ch) => char.IsLetterOrDigit(ch) || ch == '_';
+private static bool IsWhitespace(char ch) => char.IsWhiteSpace(ch);
+private static bool IsPunctuation(char ch) => !IsWordChar(ch) && !IsWhitespace(ch);
+
+		internal static void MoveToNextWordStart(ISelectionTransformer transformer, bool extend)
+		{
+		var snapshot = transformer.Selection.ActivePoint.Position.Snapshot;
+		int pos = transformer.Selection.ActivePoint.Position.Position;
+		if (pos < snapshot.Length)
+		{
+		char current = snapshot[pos];
+		if (IsWhitespace(current))
+		{
+		while (pos < snapshot.Length && IsWhitespace(snapshot[pos]))
+		{
+		pos++;
+		}
+		}
+		else if (IsWordChar(current))
+		{
+		while (pos < snapshot.Length && IsWordChar(snapshot[pos]))
+		{
+		pos++;
+		}
+		}
+		else
+		{
+		while (pos < snapshot.Length && IsPunctuation(snapshot[pos]))
+		{
+		pos++;
+		}
+		}
+		
+		while (pos < snapshot.Length && IsWhitespace(snapshot[pos]))
+		{
+		pos++;
+		}
+		}
+		
+		transformer.MoveTo(new VirtualSnapshotPoint(snapshot, pos), extend, PositionAffinity.Successor);
+		}
+		
+		internal static void MoveToPreviousWordStart(ISelectionTransformer transformer, bool extend)
+		{
+		var snapshot = transformer.Selection.ActivePoint.Position.Snapshot;
+				int pos = transformer.Selection.ActivePoint.Position.Position;
+		while (pos > 0 && IsWhitespace(snapshot[pos - 1]))
+		{
+		pos--;
+		}
+		if (pos > 0)
+		{
+		char prev = snapshot[pos - 1];
+		if (IsWordChar(prev))
+		{
+		while (pos > 0 && IsWordChar(snapshot[pos - 1]))
+		{
+		pos--;
+		}
+		}
+		else if (IsPunctuation(prev))
+		{
+		while (pos > 0 && IsPunctuation(snapshot[pos - 1]))
+		{
+		pos--;
+		}
+		}
+		else
+		{
+		while (pos > 0 && IsWhitespace(snapshot[pos - 1]))
+		{
+		pos--;
+		}
+		}
+		}
+		
+		transformer.MoveTo(new VirtualSnapshotPoint(snapshot, pos), extend, PositionAffinity.Successor);
+		}
+		
+		internal static void MoveToNextLongWordStart(ISelectionTransformer transformer, bool extend)
+		{
+		var snapshot = transformer.Selection.ActivePoint.Position.Snapshot;
+		int pos = transformer.Selection.ActivePoint.Position.Position;
+		while (pos < snapshot.Length && !IsWhitespace(snapshot[pos]))
+		pos++;
+		while (pos < snapshot.Length && IsWhitespace(snapshot[pos]))
+		pos++;
+		transformer.MoveTo(new VirtualSnapshotPoint(snapshot, pos), extend, PositionAffinity.Successor);
+		}
+		
+		internal static void MoveToPreviousLongWordStart(ISelectionTransformer transformer, bool extend)
+		{
+		var snapshot = transformer.Selection.ActivePoint.Position.Snapshot;
+		int pos = transformer.Selection.ActivePoint.Position.Position;
+		while (pos > 0 && IsWhitespace(snapshot[pos - 1]))
+		pos--;
+		while (pos > 0 && !IsWhitespace(snapshot[pos - 1]))
+		pos--;
+		transformer.MoveTo(new VirtualSnapshotPoint(snapshot, pos), extend, PositionAffinity.Successor);
+		}
+		
+		internal static void MoveToNextWordEnd(ISelectionTransformer transformer, bool extend)
+				{
+				var snapshot = transformer.Selection.ActivePoint.Position.Snapshot;
+				int pos = transformer.Selection.ActivePoint.Position.Position;
+				while (pos < snapshot.Length && IsWhitespace(snapshot[pos]))
+				pos++;
+				if (pos >= snapshot.Length)
+				{
+				transformer.MoveTo(new VirtualSnapshotPoint(snapshot, snapshot.Length), extend, PositionAffinity.Predecessor);
+				return;
+				}
+				bool word = IsWordChar(snapshot[pos]);
+				while (pos + 1 < snapshot.Length)
+				{
+		char next = snapshot[pos + 1];
+		if (word && IsWordChar(next))
+		{
+		pos++;
+		continue;
+		}
+		if (!word && IsPunctuation(next))
+		{
+		pos++;
+		continue;
+		}
+		break;
+		}
+		transformer.MoveTo(new VirtualSnapshotPoint(snapshot, pos), extend, PositionAffinity.Successor);
+		}
+		
+		internal static void MoveToNextLongWordEnd(ISelectionTransformer transformer, bool extend)
+		{
+		var snapshot = transformer.Selection.ActivePoint.Position.Snapshot;
+		int pos = transformer.Selection.ActivePoint.Position.Position;
+		while (pos < snapshot.Length && IsWhitespace(snapshot[pos]))
+		pos++;
+		if (pos >= snapshot.Length)
+		{
+		transformer.MoveTo(new VirtualSnapshotPoint(snapshot, snapshot.Length), extend, PositionAffinity.Predecessor);
+		return;
+		}
+		while (pos + 1 < snapshot.Length && !IsWhitespace(snapshot[pos + 1]))
+		pos++;
+		transformer.MoveTo(new VirtualSnapshotPoint(snapshot, pos), extend, PositionAffinity.Successor);
+		}
 			}
 		}
-	}
-}

--- a/VsHelix/VisualMode.cs
+++ b/VsHelix/VisualMode.cs
@@ -79,11 +79,13 @@ namespace VsHelix
 						sel.MoveTo(target, true, PositionAffinity.Successor);
 					}
 				},
-				['w'] = (view, sel) => sel.PerformAction(PredefinedSelectionTransformations.SelectToNextSubWord),
-				['W'] = (view, sel) => sel.PerformAction(PredefinedSelectionTransformations.SelectToNextWord),
-				['b'] = (view, sel) => sel.PerformAction(PredefinedSelectionTransformations.SelectToPreviousSubWord),
-				['B'] = (view, sel) => sel.PerformAction(PredefinedSelectionTransformations.SelectToPreviousWord)
-			};
+                               ['w'] = (view, sel) => SelectionUtils.MoveToNextWordStart(sel, true),
+                               ['W'] = (view, sel) => SelectionUtils.MoveToNextLongWordStart(sel, true),
+                               ['b'] = (view, sel) => SelectionUtils.MoveToPreviousWordStart(sel, true),
+                               ['B'] = (view, sel) => SelectionUtils.MoveToPreviousLongWordStart(sel, true),
+                               ['e'] = (view, sel) => SelectionUtils.MoveToNextWordEnd(sel, true),
+                               ['E'] = (view, sel) => SelectionUtils.MoveToNextLongWordEnd(sel, true)
+                       };
 
 			foreach (var kvp in movementCommands)
 			{


### PR DESCRIPTION
## Summary
- implement custom helpers for word movements and ends
- use custom helpers for `w`, `b`, and `e` motions
- hook up Visual mode to the same helpers

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_68886ec4f76c8324ba372a551de0fafe