### PR TITLE
Fix VSIX build step

### DIFF
--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -38,9 +38,10 @@ jobs:
       # ZipPackageCompressionLevel is set to normal to reduce the size of the VSIX
       # without sacrificing portability.
       - name: Build VSIX
-        run: msbuild VsHelix.sln \
-            /p:Configuration=Release \
-            /p:DeployExtension=false \
+        run: |
+          msbuild VsHelix.sln `
+            /p:Configuration=Release `
+            /p:DeployExtension=false `
             /p:ZipPackageCompressionLevel=normal
 
       # Create or update a release named "Nightly" and attach the generated VSIX file.


### PR DESCRIPTION
## Summary
- fix multi-line syntax in the GitHub Actions VSIX build step

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e81ac1d48324a5ee01eadf3066bd