### PR TITLE
Fix reference highlighting option

### DIFF
--- a/VsHelix/NormalModeSelectionBehavior.cs
+++ b/VsHelix/NormalModeSelectionBehavior.cs
@@ -16,7 +16,7 @@ namespace VsHelix
 		public void TextViewCreated(IWpfTextView textView)
 		{
 			textView.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);  // block caret
-			textView.Options.SetOptionValue(DefaultTextViewOptions.ReferenceHighlightingId, false);	// disable similar word highlighting
+			textView.Options.SetOptionValue(DefaultTextViewOptions.ShowSelectionMatchesId, false);	// disable similar word highlighting
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- use `ShowSelectionMatchesId` instead of missing `ReferenceHighlightingId`

## Testing
- `msbuild VsHelix.sln /restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888f35baf5083249289fa152b8cc8c4