### PR TITLE
Improve README release link

### DIFF
--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -57,4 +57,4 @@ jobs:
           allowUpdates: true
           makeLatest: true
           removeArtifacts: true
-          artifacts: VsHelix/bin/Release/VsHelix.vsix
+          artifacts: VsHelix\\bin\\Release\\VsHelix.vsix

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ VsHelix is a minimal Visual Studio extension that explores a Helix/Kakoune style
 cursor functionality as the state store.  The project now includes a basic
 command handler and will grow into a small set of core commands.
 
+You can always grab the latest nightly build from the
+[releases page](https://github.com/F286/VsHelix/releases/latest/download/VsHelix.vsix).
+
 ## Building and Running
 
 1. Install **Visual Studio 2022** with the *Visual Studio extension development*
@@ -64,22 +67,10 @@ returning to normal mode. The handler executes ahead of Visual Studio's default
 Escape logic so mode transitions always occur reliably.
 Pressing <kbd>,</kbd> clears all secondary selections, leaving a single cursor.
 Use `s` to select all matches of a regex typed inline. `/` performs an incremental search that highlights matches as you type. While searching, `n` and `N` jump to the next or previous match. Press **Enter** to accept the search or **Esc** to cancel. Enter and Backspace are now dispatched through the same keymap as other characters.
-Press `m` followed by another key to manipulate matching pairs:
-`mm` jumps to the matching bracket, `ms<char>` surrounds the selection,
-`mr<from><to>` replaces the surrounding characters, `md<char>` removes the
-surrounding pair, and `ma`/`mi <char>` select around or inside a pair.
-Press `v` toggles Visual mode where movements extend the current selections.
-While in Visual mode, motions grow the selection with a fixed anchor. Use `y`, `d`, `c`, or `p` to yank, delete, change, or replace the selections. `C` and `K` duplicate the selections down or up to form multi-line blocks. Hitting <kbd>Esc</kbd> leaves Visual mode but keeps the selection active in Normal mode.
+Press `m` followed by another key to manipulate matching pairs. `mm` jumps to the matching bracket, `ms<char>` surrounds the selection, `mr<from><to>` replaces the surrounding characters, `md<char>` removes the surrounding pair, and `ma`/`mi <char>` select around or inside a pair.
+Press `v` toggles Visual mode where movements extend the current selections. While in Visual mode, motions grow the selection with a fixed anchor. Use `y`, `d`, `c`, or `p` to yank, delete, change, or replace the selections. `C` and `K` duplicate the selections down or up to form multi-line blocks. Hitting <kbd>Esc</kbd> leaves Visual mode but keeps the selection active in Normal mode.
 
-Press `g` to enter **Goto** mode. The status bar shows `GTO` while waiting for a second key.
-`gg` jumps to a specified line number (or the start of the file), `ge` goes to the end
-of the file and `gf` opens files whose paths are under the selections. Use `gh`, `gl`
-and `gs` for the start, end, and first non-whitespace of the line. `gt`, `gc` and
-`gb` move the caret to the top, middle or bottom of the visible editor. The keys
-`gd`, `gy`, `gr` and `gi` trigger Visual Studio's Go To Definition, Type Definition,
-References and Implementation commands. `ga`/`gm` navigate backward or forward in
-file history, `gn`/`gp` switch between documents and `g.` returns to the last edit
-location. `gj` and `gk` move by textual lines.
+Press `g` to enter **Goto** mode. The status bar shows `GTO` while waiting for a second key. `gg` jumps to a specified line number (or the start of the file), `ge` goes to the end of the file and `gf` opens files whose paths are under the selections. Use `gh`, `gl` and `gs` for the start, end, and first non-whitespace of the line. `gt`, `gc` and `gb` move the caret to the top, middle or bottom of the visible editor. The keys `gd`, `gy`, `gr` and `gi` trigger Visual Studio's Go To Definition, Type Definition, References and Implementation commands. `ga`/`gm` navigate backward or forward in file history, `gn`/`gp` switch between documents and `g.` returns to the last edit location. `gj` and `gk` move by textual lines.
 
 
 ## Download


### PR DESCRIPTION
## Summary
- promote the nightly build link to the top of the README
- tidy the description of goto mode and matching pairs
- fix Windows path for the release artifact

## Testing
- `dotnet msbuild VsHelix.sln /restore /p:Configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888f73ff0dc83248e9c2ec935b3a936