### PR TITLE
Make word motions extend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can always grab the latest nightly build from the
    extension automatically loaded.
 4. Open any text file in the experimental instance.  Use
    `Ctrl+Alt+Click` to place additional carets.
-5. Use `w`, `b`, and `e` to move forward, backward, or to the end of a word.
+5. Use `w`, `b`, and `e` to select forward, backward, or to the end of a word.
    Uppercase `W`, `B`, and `E` operate on whitespace-delimited WORDs.
 6. Use `h`, `j`, `k`, and `l` to move all carets left, down, up, or right by one character or line.
 7. Carets display as thin vertical bars in both modes for a consistent insert-style look.
@@ -47,7 +47,7 @@ or using `VSIXInstaller.exe`.
 
 VsHelix exposes a `HelixCommandHandler` with bindings inspired by the Helix editor:
 
-- **Movement** – `w`, `b`, `e` move by word while `h`, `j`, `k`, and `l` move left, down, up, and right.
+ - **Movement** – `w`, `b`, `e` select by word while `h`, `j`, `k`, and `l` move left, down, up, and right.
 - **Line operations** – `x` selects the current line; `C` and <kbd>Alt</kbd>+`C` copy the selection below or above.
 - **New lines** – `o` and `O` insert lines below or above the caret and enter insert mode.
 - **Clipboard** – `y` yanks, `p` pastes, and `d`/`c` delete while yanking (hold <kbd>Alt</kbd> to delete only).

--- a/VsHelix/NormalMode.cs
+++ b/VsHelix/NormalMode.cs
@@ -159,36 +159,12 @@ namespace VsHelix
 
 
 				// Word-wise movements (clear selection then extend)
-				['w'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					SelectionUtils.MoveToNextWordStart(sel, false);
-				},  // Next word
-				['W'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					SelectionUtils.MoveToNextLongWordStart(sel, false);
-				},  // Next WORD
-				['b'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					SelectionUtils.MoveToPreviousWordStart(sel, false);
-				},  // Previous word
-				['B'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					SelectionUtils.MoveToPreviousLongWordStart(sel, false);
-				},  // Previous WORD
-				['e'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					SelectionUtils.MoveToNextWordEnd(sel, false);
-				},  // End of word
-				['E'] = sel =>
-				{
-					sel.PerformAction(PredefinedSelectionTransformations.ClearSelection);
-					SelectionUtils.MoveToNextLongWordEnd(sel, false);
-				}   // End of WORD
+                                ['w'] = sel => SelectionUtils.MoveToNextWordStart(sel, true),  // Next word
+                                ['W'] = sel => SelectionUtils.MoveToNextLongWordStart(sel, true),  // Next WORD
+                                ['b'] = sel => SelectionUtils.MoveToPreviousWordStart(sel, true),  // Previous word
+                                ['B'] = sel => SelectionUtils.MoveToPreviousLongWordStart(sel, true),  // Previous WORD
+                                ['e'] = sel => SelectionUtils.MoveToNextWordEnd(sel, true),  // End of word
+                                ['E'] = sel => SelectionUtils.MoveToNextLongWordEnd(sel, true)   // End of WORD
 			};
 
 			// Register all movement commands to the command map.


### PR DESCRIPTION
## Summary
- extend Normal mode word motions to select like Helix
- document word selections in README

## Testing
- `msbuild VsHelix.sln /restore` *(fails: command not found)*
- `xbuild VsHelix.sln` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_688932df25c88324b69b4102a8a4b081