### PR TITLE
Disable under-caret highlights outside insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can always grab the latest nightly build from the
    Uppercase `W`, `B`, and `E` operate on whitespace-delimited WORDs.
 6. Use `h`, `j`, `k`, and `l` to move all carets left, down, up, or right by one character or line.
 7. Carets display as thin vertical bars in both modes for a consistent insert-style look.
-8. Reference highlighting is disabled in Normal mode so only the actual selection is shown.
+8. Reference highlighting is disabled in Normal and Visual modes so only the actual selection is shown.
 
 The provided `VsHelixPackage` is a standard AsyncPackage.  Command handlers are
 added via MEF exports.  When the project is built in *Release* configuration it

--- a/VsHelix/ModeManager.cs
+++ b/VsHelix/ModeManager.cs
@@ -43,6 +43,7 @@ namespace VsHelix
 			Current = EditorMode.Insert;
 			StatusBarHelper.ShowMode(Current);
 			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, false);
+			view.Options.SetOptionValue(DefaultTextViewOptions.ShowSelectionMatchesId, true);
 		}
 
 		public void EnterVisual(ITextView view, IMultiSelectionBroker broker)
@@ -50,6 +51,7 @@ namespace VsHelix
 			Current = EditorMode.Visual;
 			StatusBarHelper.ShowMode(Current);
 			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);
+			view.Options.SetOptionValue(DefaultTextViewOptions.ShowSelectionMatchesId, false);
 		}
 
 		public void EnterSearch(ITextView view, IMultiSelectionBroker broker, bool selectAll, System.Collections.Generic.List<SnapshotSpan> domain)
@@ -73,6 +75,7 @@ namespace VsHelix
 			_searchMode = null;
 			StatusBarHelper.ShowMode(Current);
 			view.Options.SetOptionValue(DefaultTextViewOptions.OverwriteModeId, true);  // block caret
+			view.Options.SetOptionValue(DefaultTextViewOptions.ShowSelectionMatchesId, false);
 
 		}
 	}


### PR DESCRIPTION
## Summary
- toggle `ShowSelectionMatchesId` option when switching modes
- update docs about reference highlighting behavior

## Testing
- `dotnet msbuild VsHelix.sln /restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889fa3a11dc83248b7ef21b0f1dba0e