### PR TITLE
Implement miw/maw word text objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ VsHelix exposes a `HelixCommandHandler` with bindings inspired by the Helix edit
 - **Selections** – `,` clears secondary selections and `v` toggles Visual mode for selection growth.
 - **Search** – `s` selects regex matches and `/` performs an incremental search navigated with `n`/`N`.
 - **Pairs** – `m` commands jump to, surround, or modify matching brackets and quotes.
+- **Text objects** – `miw`/`maw` select the word under the caret. Use uppercase `W` for whitespace-delimited WORDs.
 - **Misc** – `u`/`U` undo and redo, numeric prefixes repeat commands, and <kbd>Esc</kbd> exits to Normal mode.
 - **Goto mode** – `g` followed by another key jumps to lines, files, or definitions.
 ## Download

--- a/VsHelix/SelectionUtils.cs
+++ b/VsHelix/SelectionUtils.cs
@@ -333,5 +333,54 @@ namespace VsHelix
 				pos++;
 			transformer.MoveTo(new VirtualSnapshotPoint(snapshot, pos), extend, PositionAffinity.Successor);
 		}
+		/// <summary>
+		/// Calculates the boundaries of a word or WORD at the specified position.
+		/// </summary>
+		internal static void GetWordExtent(ITextSnapshot snapshot, int position, bool longWord, out int start, out int end)
+		{
+			start = end = position;
+			if (position < 0 || position >= snapshot.Length)
+				return;
+
+			while (position < snapshot.Length && IsWhitespace(snapshot[position]))
+				position++;
+			if (position >= snapshot.Length)
+				return;
+
+			bool isWord = longWord ? !IsWhitespace(snapshot[position]) : IsWordChar(snapshot[position]);
+
+			start = position;
+			end = position + 1;
+
+			while (start > 0)
+			{
+				char prev = snapshot[start - 1];
+				bool match = longWord ? !IsWhitespace(prev) : (isWord ? IsWordChar(prev) : IsPunctuation(prev));
+				if (!match)
+					break;
+				start--;
+			}
+
+			while (end < snapshot.Length)
+			{
+				char next = snapshot[end];
+				bool match = longWord ? !IsWhitespace(next) : (isWord ? IsWordChar(next) : IsPunctuation(next));
+				if (!match)
+					break;
+				end++;
+			}
+		}
+
+		/// <summary>
+		/// Expands a span to include neighbouring whitespace.
+		/// </summary>
+		internal static void ExpandToWhitespace(ITextSnapshot snapshot, ref int start, ref int end)
+		{
+			while (start > 0 && IsWhitespace(snapshot[start - 1]))
+				start--;
+			while (end < snapshot.Length && IsWhitespace(snapshot[end]))
+				end++;
+		}
+
 	}
 }


### PR DESCRIPTION
## Summary
- add `GetWordExtent` and `ExpandToWhitespace` helpers
- extend `SelectTextObject` to handle `w` and `W`
- document new text object commands in README

## Testing
- `msbuild VsHelix.sln /restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889faab709883249f143694d7d78c87